### PR TITLE
feat(9k9.217.5): codex-arm recovery ladder moves into deterministic JS with retry observability

### DIFF
--- a/.claude/workflows/bake-off.js
+++ b/.claude/workflows/bake-off.js
@@ -1,7 +1,7 @@
 export const meta = {
   name: 'bake-off',
   description: 'Parameterized model×effort bake-off: reset worktrees, run contestant arms, audit+gate, sanitize, blind-judge, synthesize',
-  whenToUse: 'Run a pinned task across contestant arms (Claude native or codex exec) and judge the outputs blind. Args: {task, base, dir, briefText, rubricText, arms[], judges[], reconcile?, reset?}. Judge-only re-judging of retained artifacts: {judgeOnly: true, dir, labels[], gateSummary, rubricText, judges[], cachedSeats?, cachedChecker?}.',
+  whenToUse: 'Run a pinned task across contestant arms (Claude native or codex exec) and judge the outputs blind. Args: {task, base, dir, briefText, rubricText, arms[], judges[], runnerPath (required for codex arms), reconcile?, reset?, maxAttempts?, watchdogSeconds?, rungTimeoutMs?}. Judge-only re-judging of retained artifacts: {judgeOnly: true, dir, labels[], gateSummary, rubricText, judges[], cachedSeats?, cachedChecker?}.',
   phases: [
     { title: 'Reset', detail: 'archive then reset each arm worktree to the pinned base' },
     { title: 'Arms', detail: 'contestants implement the pinned brief in isolated worktrees' },
@@ -25,6 +25,15 @@ const BASE = IN.base
 const RESET = IN.reset !== false
 const JUDGES = IN.judges && IN.judges.length ? IN.judges : [{ id: 'J1', kind: 'claude', model: 'sonnet', effort: 'high' }]
 const GATE_CMD = IN.gateCmd || 'make ci'
+// Codex arms run through the versioned single-attempt runner script; every
+// recovery decision (resume / fresh retry / stop) is made here in plain JS from
+// the rung's state JSON — the wrapper agent is transport only. The runner's
+// in-code watchdog stays strictly below the rung's Bash-call timeout, so the
+// harness's background-on-timeout branch is unreachable inside a rung.
+const RUNNER = IN.runnerPath || null
+const MAX_ATTEMPTS = IN.maxAttempts || 4
+const WATCHDOG_S = IN.watchdogSeconds || 1200
+const RUNG_TIMEOUT_MS = IN.rungTimeoutMs || 1740000
 // Exact JSON keys for the rubric's quality axes. When set, judge prompts name them
 // and the judge schema pins them — without this, seats derive keys from the rubric's
 // prose axis titles and drift (fit_and_scope vs fit_scope), splitting the axis means.
@@ -65,6 +74,9 @@ if (!IN.rubricText) throw new Error('bake-off: rubricText is required — judge 
 if (!JUDGE_ONLY && (IN.arms || []).some(a => a.kind !== 'reference') && !IN.briefText) {
   throw new Error('bake-off: briefText is required when contestant arms run')
 }
+if (!JUDGE_ONLY && (IN.arms || []).some(a => a.kind !== 'reference' && a.kind !== 'claude') && !RUNNER) {
+  throw new Error('bake-off: runnerPath (absolute path to run_codex_arm.py) is required when codex arms run')
+}
 
 // Prompts embed these values inside Bash commands without shell quoting; restrict
 // them to shell-inert characters and fail fast, rather than quoting throughout the
@@ -72,6 +84,7 @@ if (!JUDGE_ONLY && (IN.arms || []).some(a => a.kind !== 'reference') && !IN.brie
 const SHELL_INERT = /^[A-Za-z0-9._/-]+$/
 const embedded = [['dir', DIR], ['base', BASE], ['contextCheckout', IN.contextCheckout]]
 if (TRAP_LEDGER) embedded.push(['trapLedgerPath', TRAP_LEDGER])
+if (RUNNER) embedded.push(['runnerPath', RUNNER])
 for (const a of IN.arms || []) {
   embedded.push([`arm ${a.label} label`, a.label], [`arm ${a.label} worktree`, a.worktree])
   if (a.runTag) embedded.push([`arm ${a.label} runTag`, a.runTag])
@@ -108,30 +121,34 @@ function claudeArmPrompt(arm) {
   return `Dispatch preamble (run tag ${tag(arm)}): your working root is ${arm.worktree}. Your report path is ${reportPath(arm)}. The brief follows.\n\n${IN.briefText}`
 }
 
-function codexArmPrompt(arm) {
-  return `You are a mechanical harness runner (run tag ${tag(arm)}). Execute exactly the steps below with the Bash tool. Do not improvise, do not edit any file, do not interpret the task the runner executes — your job is transport and capture only.
+// One rung = one runner-script invocation = one codex attempt. The script owns
+// the mechanics (dispatch write + self-check guard, pidfile guard, in-code
+// watchdog, state capture); the transport agent owns nothing but the call.
+function rungCmd(arm, attempt, sessionId) {
+  return `python3 ${RUNNER} --dir ${DIR} --worktree ${arm.worktree} --label ${arm.label} --model ${arm.codexModel} --effort ${arm.effort} --base ${BASE} --brief ${DIR}/brief.md --report-path ${reportPath(arm)} --run-tag ${tag(arm)} --attempt ${attempt} --watchdog-seconds ${WATCHDOG_S}${sessionId ? ` --resume-session ${sessionId}` : ''}`
+}
 
-Step 0 — write the dispatch file: mkdir -p ${DIR}/reports && printf '%s\\n\\n' "Dispatch preamble (run tag ${tag(arm)}): your working root is ${arm.worktree}. Your report path is ${reportPath(arm)}. The brief follows." > ${DIR}/dispatch-${arm.label}.md — then append the brief, which is already on disk at ${DIR}/brief.md: cat ${DIR}/brief.md >> ${DIR}/dispatch-${arm.label}.md
+function rungPrompt(arm, attempt, sessionId) {
+  return `You are a mechanical transport runner (run tag ${tag(arm)}) for one attempt of bake-off arm ${arm.label}. Execute exactly ONE foreground Bash call, with timeout ${RUNG_TIMEOUT_MS}, running exactly this command and nothing else:
 
-Step 1 — run the runner as ONE FOREGROUND Bash call with timeout 600000 (do NOT use run_in_background — the runner must finish inside this one call):
+${rungCmd(arm, attempt, sessionId)}
 
-date +%s > ${DIR}/${arm.label}.start; codex exec -C ${arm.worktree} -m ${arm.codexModel} -c model_reasoning_effort=${arm.effort} -s workspace-write --add-dir ${DIR}/reports -o ${DIR}/reports/arm-${arm.label}.last.md - < ${DIR}/dispatch-${arm.label}.md > ${DIR}/${arm.label}.exec.log 2>&1; echo "CODEX_EXIT=$?" >> ${DIR}/${arm.label}.exec.log; date +%s > ${DIR}/${arm.label}.end
+The command supervises its own subprocess under an internal watchdog shorter than your timeout, so it always exits on its own — never use run_in_background, never re-run it, and never run any other codex command. Its final stdout line is a single JSON object: return that object as your structured result, every field copied verbatim. If the call printed no JSON line, return the required fields as codex_exit -1, session_id "", report_exists false, worktree_touched false, log_tail = the last lines you saw, and set rung_error to the exit code and what happened. Report only observed values; never invent one.`
+}
 
-Step 1b — completion ladder (a high-effort runner can outlast one call):
-(a) If the harness reports the Step 1 command was moved to the background on timeout, WAIT for its completion notification — never start another codex process while one may still be running for this arm.
-(b) Only after the command has fully ended, check the tail of ${DIR}/${arm.label}.exec.log. If NO CODEX_EXIT line was recorded, the runner was killed mid-flight: extract the bare session UUID with: grep -m1 -oE 'session id: [0-9a-f-]+' ${DIR}/${arm.label}.exec.log | cut -d' ' -f3 — then run as ONE FOREGROUND Bash call with timeout 600000: codex exec resume <that-uuid> -o ${DIR}/reports/arm-${arm.label}.last.md - <<< "Continue where you left off and finish the original dispatch; your working root, report path, and constraints are unchanged." >> ${DIR}/${arm.label}.exec.log 2>&1; echo "CODEX_EXIT=$?" >> ${DIR}/${arm.label}.exec.log; date +%s > ${DIR}/${arm.label}.end
-Apply rules (a) and (b) to each resume call too, resuming the SAME session id, at most 3 resumes total. If no session id is found in the log, record what happened for log_tail and continue.
+// When a transport agent dies or returns garbage, the rung's true state is
+// still on disk — a probe reconstructs it and the ladder continues.
+function probePrompt(arm) {
+  return `You are a mechanical state prober (run tag ${tag(arm)}) for bake-off arm ${arm.label}. A transport agent failed to deliver this arm's attempt state; the state lives on disk. Execute with Bash, changing nothing:
 
-Step 2 — retry rule, applied at most once: if the recorded CODEX_EXIT is non-zero AND \`git -C ${arm.worktree} status --porcelain\` is empty AND \`git -C ${arm.worktree} log --oneline ${BASE}..HEAD\` is empty (a transport-class failure that produced no work — e.g. an HTTP 5xx in the log), run the Step 1 command once more. If the worktree has changes or commits, never re-run — capture what is there.
+1. tail -c 2000 ${DIR}/${arm.label}.exec.log
+2. the LAST CODEX_EXIT= value in that log (grep -oE 'CODEX_EXIT=-?[0-9]+' ${DIR}/${arm.label}.exec.log | tail -1)
+3. grep -m1 -oE 'session id: [0-9a-f-]+' ${DIR}/${arm.label}.exec.log | cut -d' ' -f3
+4. test -s ${reportPath(arm)} && echo REPORT_EXISTS || echo NO_REPORT
+5. git -C ${arm.worktree} status --porcelain — and: git -C ${arm.worktree} log --oneline ${BASE}..HEAD
+6. P=$(cat ${DIR}/${arm.label}.pid 2>/dev/null); [ -n "$P" ] && kill -0 $P 2>/dev/null && echo PID_ALIVE || echo NO_LIVE_PID
 
-Step 3 — capture with plain foreground reads:
-- CODEX_EXIT from the last lines of ${DIR}/${arm.label}.exec.log
-- the "tokens used" figure printed near the end of that log (0 if absent)
-- wall seconds = the number in ${DIR}/${arm.label}.end minus the number in ${DIR}/${arm.label}.start
-- whether ${reportPath(arm)} exists; if it does NOT exist but ${DIR}/reports/arm-${arm.label}.last.md does, copy the .last.md file to ${reportPath(arm)} (the runner's final message is its report)
-- the last 25 lines of ${DIR}/${arm.label}.exec.log
-
-Then return the structured result. Report ONLY observed values — if a value was never observed (timeout, launch failure), use -1 for it and say exactly what happened in log_tail. Never invent a number.`
+Return the structured result: codex_exit = the last CODEX_EXIT value, or -1 if none; watchdog_fired false; session_id = the bare uuid or ""; report_exists per step 4; worktree_touched = true if step 5 printed anything at all; tokens_used 0; wall_seconds -1; total_wall_seconds -1; log_tail = the step-1 tail; probe true; pid_alive per step 6. Report only observed values; never guess.`
 }
 
 function auditPrompt(arm) {
@@ -224,16 +241,29 @@ const RESET_SCHEMA = {
   required: ['was_dirty', 'archived', 'head_ok', 'notes'],
 }
 
-const WRAPPER_SCHEMA = {
+// State of one codex attempt, as the runner script prints it (a probe returns
+// the same shape reconstructed from disk). rung_error marks transport failure.
+const RUNG_SCHEMA = {
   type: 'object',
   properties: {
+    label: { type: 'string' },
+    attempt: { type: 'integer' },
+    kind: { type: 'string' },
     codex_exit: { type: 'integer' },
+    watchdog_fired: { type: 'boolean' },
+    session_id: { type: 'string' },
+    report_exists: { type: 'boolean' },
+    report_copied: { type: 'boolean' },
+    worktree_touched: { type: 'boolean' },
     tokens_used: { type: 'integer' },
     wall_seconds: { type: 'integer' },
-    report_exists: { type: 'boolean' },
+    total_wall_seconds: { type: 'integer' },
     log_tail: { type: 'string' },
+    probe: { type: 'boolean' },
+    pid_alive: { type: 'boolean' },
+    rung_error: { type: 'string' },
   },
-  required: ['codex_exit', 'tokens_used', 'wall_seconds', 'report_exists', 'log_tail'],
+  required: ['codex_exit', 'session_id', 'report_exists', 'worktree_touched', 'log_tail'],
 }
 
 const AUDIT_SCHEMA = {
@@ -360,6 +390,54 @@ const ESCALATION_SCHEMA_BASE = labels => ({
   required: ['ruling', 'own_arm_preference', 'notes'],
 })
 
+// ---------- codex-arm ladder ----------
+
+// The recovery ladder, in deterministic JS. Each iteration spawns one rung
+// (one runner-script attempt); the decisions — done, resume, one fresh retry
+// on a launch-level failure with a provably untouched worktree, or stop —
+// happen here from the rung's state JSON. A dead transport agent costs a disk
+// probe, not the arm. The full history is returned for observability and is
+// deliberately kept out of gateSummary and every judge prompt: a retry count
+// is both a bias vector and an unblinding hint.
+async function runCodexLadder(arm) {
+  const history = []
+  let sessionId = ''
+  let freshRetryUsed = false
+  let outcome = 'attempts_exhausted'
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    const kind = sessionId ? 'resume' : (attempt === 1 ? 'initial' : 'retry')
+    let state = await agent(rungPrompt(arm, attempt, sessionId), { label: `arm:${arm.label}:a${attempt}`, phase: 'Arms', model: 'haiku', effort: 'low', schema: RUNG_SCHEMA })
+    if (!state || state.rung_error) {
+      log(`ARM ${arm.label}: attempt ${attempt} transport ${state ? `error (${state.rung_error})` : 'lost'} — probing disk state`)
+      state = await agent(probePrompt(arm), { label: `probe:${arm.label}:a${attempt}`, phase: 'Arms', model: 'haiku', effort: 'low', schema: RUNG_SCHEMA })
+    }
+    if (!state) { outcome = 'state_unrecoverable'; history.push({ attempt, kind, outcome }); break }
+    history.push({ attempt, kind, codex_exit: state.codex_exit, watchdog_fired: !!state.watchdog_fired, wall_seconds: state.wall_seconds, report_exists: !!state.report_exists, probed: !!state.probe })
+    sessionId = state.session_id || sessionId
+    if (state.pid_alive) {
+      log(`ARM ${arm.label}: a codex process for this arm is still alive after transport loss — stopping rather than racing it`)
+      outcome = 'live_process_orphaned'
+      break
+    }
+    if (state.codex_exit === 0 && state.report_exists) { outcome = 'completed'; break }
+    if (sessionId) {
+      log(`ARM ${arm.label}: attempt ${attempt} incomplete (exit ${state.codex_exit}${state.watchdog_fired ? ', watchdog' : ''}) — resuming session`)
+      continue
+    }
+    if (!state.worktree_touched && !freshRetryUsed) {
+      freshRetryUsed = true
+      log(`ARM ${arm.label}: launch-level failure with untouched worktree — one fresh retry`)
+      continue
+    }
+    log(`ARM ${arm.label}: attempt ${attempt} failed with no session to resume and ${state.worktree_touched ? 'a touched worktree' : 'the retry spent'} — stopping`)
+    outcome = 'unrecoverable_failure'
+    break
+  }
+  const resumed = history.filter(h => h.kind === 'resume').length
+  if (outcome !== 'completed' || history.length > 1) log(`ARM ${arm.label}: ladder ${outcome} after ${history.length} attempt(s), ${resumed} resume(s)`)
+  return { ladder: { outcome, attempts: history.length, resumed, history } }
+}
+
 // ---------- pipeline ----------
 
 // Per arm: (reset →) contestant → audit → sanitize, no cross-arm barrier until judging.
@@ -381,8 +459,7 @@ const armResults = await pipeline(
     : arm.kind === 'claude'
       ? agent(claudeArmPrompt(arm), { label: `arm:${arm.label}`, phase: 'Arms', model: arm.model, effort: arm.effort })
           .then(r => ({ resetResult, contestant: r }))
-      : agent(codexArmPrompt(arm), { label: `arm:${arm.label}`, phase: 'Arms', model: 'haiku', effort: 'low', schema: WRAPPER_SCHEMA })
-          .then(r => ({ resetResult, contestant: r })),
+      : runCodexLadder(arm).then(r => ({ resetResult, contestant: r })),
   (prev, arm) => agent(auditPrompt(arm), { label: `audit:${arm.label}`, phase: 'Audit', model: 'haiku', effort: 'low', schema: AUDIT_SCHEMA })
     .then(audit => ({ ...prev, audit })),
   (prev, arm) => agent(sanitizePrompt(arm), { label: `sanitize:${arm.label}`, phase: 'Sanitize', model: 'sonnet', effort: 'low', schema: SANITIZE_SCHEMA })
@@ -397,6 +474,9 @@ const armResults = await pipeline(
 
 arms = armResults.filter(Boolean)
 log(`Arms complete: ${arms.length}/${IN.arms.length}. Gates: ${arms.map(a => `${a.arm}=${a.audit ? a.audit.gate_exit : '?'}`).join(', ')}`)
+const ladderSummary = arms.filter(a => a.contestant && a.contestant.ladder)
+  .map(a => `${a.arm}=${a.contestant.ladder.outcome}:${a.contestant.ladder.attempts}att/${a.contestant.ladder.resumed}res`)
+if (ladderSummary.length) log(`Codex ladders (outcome:attempts/resumes): ${ladderSummary.join(', ')}`)
 } else {
   log(`Judge-only: judging retained artifacts in ${DIR} — ${IN.labels.length} arm(s), ${CACHED_SEATS.length} cached seat(s)${CACHED_CHECKER ? ', cached checker' : ''}`)
 }

--- a/.claude/workflows/bake-off.js
+++ b/.claude/workflows/bake-off.js
@@ -74,8 +74,20 @@ if (!IN.rubricText) throw new Error('bake-off: rubricText is required — judge 
 if (!JUDGE_ONLY && (IN.arms || []).some(a => a.kind !== 'reference') && !IN.briefText) {
   throw new Error('bake-off: briefText is required when contestant arms run')
 }
-if (!JUDGE_ONLY && (IN.arms || []).some(a => a.kind !== 'reference' && a.kind !== 'claude') && !RUNNER) {
+const codexArms = JUDGE_ONLY ? [] : (IN.arms || []).filter(a => a.kind !== 'reference' && a.kind !== 'claude')
+if (codexArms.length && !RUNNER) {
   throw new Error('bake-off: runnerPath (absolute path to run_codex_arm.py) is required when codex arms run')
+}
+if (RUNNER && !RUNNER.startsWith('/')) {
+  throw new Error('bake-off: runnerPath must be absolute — rung agents start in the session root, not this checkout')
+}
+// The ladder's no-backgrounding guarantee IS this inequality: the runner's
+// watchdog must expire with margin inside the rung's Bash-call timeout.
+if (codexArms.length && WATCHDOG_S * 1000 > RUNG_TIMEOUT_MS - 60000) {
+  throw new Error(`bake-off: watchdogSeconds (${WATCHDOG_S}s) must sit at least 60s inside rungTimeoutMs (${RUNG_TIMEOUT_MS}ms)`)
+}
+for (const a of codexArms) {
+  if (!a.codexModel || !a.effort) throw new Error(`bake-off: codex arm ${a.label} needs codexModel and effort`)
 }
 
 // Prompts embed these values inside Bash commands without shell quoting; restrict
@@ -87,6 +99,7 @@ if (TRAP_LEDGER) embedded.push(['trapLedgerPath', TRAP_LEDGER])
 if (RUNNER) embedded.push(['runnerPath', RUNNER])
 for (const a of IN.arms || []) {
   embedded.push([`arm ${a.label} label`, a.label], [`arm ${a.label} worktree`, a.worktree])
+  if (a.codexModel) embedded.push([`arm ${a.label} codexModel`, a.codexModel], [`arm ${a.label} effort`, a.effort])
   if (a.runTag) embedded.push([`arm ${a.label} runTag`, a.runTag])
   if (a.reportPath) embedded.push([`arm ${a.label} reportPath`, a.reportPath])
 }
@@ -262,6 +275,7 @@ const RUNG_SCHEMA = {
     probe: { type: 'boolean' },
     pid_alive: { type: 'boolean' },
     rung_error: { type: 'string' },
+    guard_exit: { type: 'integer' },
   },
   required: ['codex_exit', 'session_id', 'report_exists', 'worktree_touched', 'log_tail'],
 }
@@ -407,11 +421,19 @@ async function runCodexLadder(arm) {
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
     const kind = sessionId ? 'resume' : (attempt === 1 ? 'initial' : 'retry')
     let state = await agent(rungPrompt(arm, attempt, sessionId), { label: `arm:${arm.label}:a${attempt}`, phase: 'Arms', model: 'haiku', effort: 'low', schema: RUNG_SCHEMA })
-    if (!state || state.rung_error) {
+    // A guard exit is a deliberate stop the script already explained — probe
+    // only when the transport itself failed to deliver a rung state.
+    if (!state || (state.rung_error && state.guard_exit == null)) {
       log(`ARM ${arm.label}: attempt ${attempt} transport ${state ? `error (${state.rung_error})` : 'lost'} — probing disk state`)
       state = await agent(probePrompt(arm), { label: `probe:${arm.label}:a${attempt}`, phase: 'Arms', model: 'haiku', effort: 'low', schema: RUNG_SCHEMA })
     }
     if (!state) { outcome = 'state_unrecoverable'; history.push({ attempt, kind, outcome }); break }
+    if (state.guard_exit != null) {
+      log(`ARM ${arm.label}: runner guard stop (exit ${state.guard_exit}): ${state.rung_error}`)
+      outcome = `guard_stop_${state.guard_exit}`
+      history.push({ attempt, kind, guard_exit: state.guard_exit, outcome })
+      break
+    }
     history.push({ attempt, kind, codex_exit: state.codex_exit, watchdog_fired: !!state.watchdog_fired, wall_seconds: state.wall_seconds, report_exists: !!state.report_exists, probed: !!state.probe })
     sessionId = state.session_id || sessionId
     if (state.pid_alive) {

--- a/.claude/workflows/bake-off/run_codex_arm.py
+++ b/.claude/workflows/bake-off/run_codex_arm.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Single-attempt codex arm runner for the bake-off workflow.
+
+Executes exactly ONE codex attempt (initial launch or session resume) under an
+in-code watchdog, then prints a one-line state JSON to stdout. Every recovery
+decision — resume, fresh retry, stop — belongs to the calling workflow
+(bake-off.js), never to this script and never to the wrapper agent running it.
+
+The watchdog must be strictly below the harness Bash-call timeout the wrapper
+uses: the script then always exits inside its one foreground call, so the
+harness's background-on-timeout branch is unreachable rather than merely
+unlikely.
+
+Script-level failures use enumerated exit codes (state JSON still printed):
+  0  attempt executed (codex_exit in the JSON tells how codex itself fared)
+  2  argparse usage error
+ 12  dispatch guard: dispatch file does not name this arm's worktree + report
+ 13  pidfile guard: a codex process for this arm is still alive
+ 14  codex binary not found
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+CONTINUATION = (
+    "Continue where you left off and finish the original dispatch; your "
+    "working root, report path, and constraints are unchanged."
+)
+LOG_TAIL_LINES = 25
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--dir", required=True, help="run directory (DIR)")
+    p.add_argument("--worktree", required=True)
+    p.add_argument("--label", required=True)
+    p.add_argument("--model", required=True)
+    p.add_argument("--effort", required=True)
+    p.add_argument("--base", required=True, help="pinned base commit")
+    p.add_argument("--brief", help="brief file; required on the first attempt")
+    p.add_argument("--report-path", default=None)
+    p.add_argument("--run-tag", default="1")
+    p.add_argument("--attempt", type=int, default=1)
+    p.add_argument("--kind", choices=["initial", "resume", "retry"], default=None)
+    p.add_argument("--resume-session", default=None, help="codex session UUID to resume")
+    p.add_argument("--watchdog-seconds", type=int, default=1200)
+    p.add_argument("--codex-bin", default="codex")
+    return p.parse_args(argv)
+
+
+def emit(state: dict, code: int = 0) -> int:
+    print(json.dumps(state, separators=(",", ":")))
+    return code
+
+
+def tail(path: Path, lines: int = LOG_TAIL_LINES) -> str:
+    if not path.exists():
+        return ""
+    return "\n".join(path.read_text(errors="replace").splitlines()[-lines:])
+
+
+def first_session_id(log: Path) -> str:
+    if not log.exists():
+        return ""
+    m = re.search(r"session id: ([0-9a-f-]+)", log.read_text(errors="replace"))
+    return m.group(1) if m else ""
+
+
+def last_tokens_used(log: Path) -> int:
+    if not log.exists():
+        return 0
+    hits = re.findall(r"tokens used[:= ]+([0-9,]+)", log.read_text(errors="replace"))
+    return int(hits[-1].replace(",", "")) if hits else 0
+
+
+def git(worktree: str, *args: str) -> str:
+    r = subprocess.run(
+        ["git", "-C", worktree, *args], capture_output=True, text=True, timeout=60
+    )
+    return r.stdout.strip()
+
+
+def worktree_touched(worktree: str, base: str) -> bool:
+    return bool(git(worktree, "status", "--porcelain")) or bool(
+        git(worktree, "log", "--oneline", f"{base}..HEAD")
+    )
+
+
+def main(argv: list[str]) -> int:
+    a = parse_args(argv)
+    d = Path(a.dir)
+    label = a.label
+    report = Path(a.report_path or d / "reports" / f"arm-{label}.md")
+    last_msg = d / "reports" / f"arm-{label}.last.md"
+    dispatch = d / f"dispatch-{label}.md"
+    exec_log = d / f"{label}.exec.log"
+    pidfile = d / f"{label}.pid"
+    ladder_log = d / f"{label}.ladder.jsonl"
+    kind = a.kind or ("resume" if a.resume_session else ("initial" if a.attempt == 1 else "retry"))
+
+    state: dict = {"label": label, "attempt": a.attempt, "kind": kind, "run_tag": a.run_tag}
+
+    # Pidfile guard: never start a second codex while one may still be running
+    # for this arm — resuming under a live process would race it on the worktree.
+    if pidfile.exists():
+        try:
+            pid = int(pidfile.read_text().strip())
+            os.kill(pid, 0)
+        except (ValueError, ProcessLookupError, PermissionError):
+            pidfile.unlink(missing_ok=True)
+        else:
+            state["error"] = f"pidfile guard: codex pid {pid} for arm {label} is still alive"
+            return emit(state, 13)
+
+    # First attempt owns the dispatch file and truncates the log; later
+    # attempts reuse both so the session's full history stays in one place.
+    (d / "reports").mkdir(parents=True, exist_ok=True)
+    if a.attempt == 1 or not dispatch.exists():
+        if not a.brief:
+            state["error"] = "dispatch guard: --brief is required to write the dispatch file"
+            return emit(state, 12)
+        preamble = (
+            f"Dispatch preamble (run tag {a.run_tag}): your working root is "
+            f"{a.worktree}. Your report path is {report}. The brief follows."
+        )
+        dispatch.write_text(preamble + "\n\n" + Path(a.brief).read_text())
+    if a.attempt == 1:
+        exec_log.write_text("")
+        (d / f"{label}.start").write_text(f"{int(time.time())}\n")
+
+    # Dispatch guard: the file this attempt feeds to codex must name this arm's
+    # own worktree and report path — a mispaired dispatch stops here, loudly,
+    # instead of silently running another arm's task.
+    text = dispatch.read_text(errors="replace")
+    if a.worktree not in text or str(report) not in text:
+        state["error"] = (
+            f"dispatch guard: {dispatch} does not name worktree {a.worktree} "
+            f"and report path {report}"
+        )
+        return emit(state, 12)
+
+    if a.resume_session:
+        cmd = [a.codex_bin, "exec", "resume", a.resume_session, "-o", str(last_msg), "-"]
+        stdin_bytes = CONTINUATION.encode()
+    else:
+        cmd = [
+            a.codex_bin, "exec", "-C", a.worktree, "-m", a.model,
+            "-c", f"model_reasoning_effort={a.effort}",
+            "-s", "workspace-write", "--add-dir", str(d / "reports"),
+            "-o", str(last_msg), "-",
+        ]
+        stdin_bytes = dispatch.read_bytes()
+
+    started = int(time.time())
+    watchdog_fired = False
+    try:
+        with exec_log.open("ab") as logf:
+            logf.write(f"--- attempt {a.attempt} ({kind}) ---\n".encode())
+            logf.flush()
+            proc = subprocess.Popen(
+                cmd, stdin=subprocess.PIPE, stdout=logf, stderr=logf,
+                start_new_session=True,
+            )
+            pidfile.write_text(str(proc.pid))
+            try:
+                proc.communicate(input=stdin_bytes, timeout=a.watchdog_seconds)
+                rc = proc.returncode
+            except subprocess.TimeoutExpired:
+                watchdog_fired = True
+                os.killpg(proc.pid, signal.SIGKILL)
+                proc.wait(timeout=30)
+                rc = 137
+    except FileNotFoundError:
+        pidfile.unlink(missing_ok=True)
+        state["error"] = f"codex binary not found: {a.codex_bin}"
+        return emit(state, 14)
+    finally:
+        pidfile.unlink(missing_ok=True)
+
+    ended = int(time.time())
+    (d / f"{label}.end").write_text(f"{ended}\n")
+    with exec_log.open("a") as logf:
+        logf.write(f"CODEX_EXIT={rc}\n")
+
+    report_copied = False
+    if not report.exists() and last_msg.exists() and last_msg.stat().st_size > 0:
+        shutil.copyfile(last_msg, report)
+        report_copied = True
+
+    start_file = d / f"{label}.start"
+    total_wall = ended - int(start_file.read_text().strip()) if start_file.exists() else -1
+    state.update(
+        codex_exit=rc,
+        watchdog_fired=watchdog_fired,
+        session_id=first_session_id(exec_log),
+        report_exists=report.exists(),
+        report_copied=report_copied,
+        worktree_touched=worktree_touched(a.worktree, a.base),
+        tokens_used=last_tokens_used(exec_log),
+        wall_seconds=ended - started,
+        total_wall_seconds=total_wall,
+        log_tail=tail(exec_log),
+    )
+    with ladder_log.open("a") as f:
+        f.write(json.dumps(state, separators=(",", ":")) + "\n")
+    return emit(state, 0)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.claude/workflows/bake-off/run_codex_arm.py
+++ b/.claude/workflows/bake-off/run_codex_arm.py
@@ -63,6 +63,27 @@ def emit(state: dict, code: int = 0) -> int:
     return code
 
 
+def emit_guard(state: dict, message: str, code: int) -> int:
+    """Guard/launch failures still emit the full rung-state shape: the caller's
+    schema requires those fields, and a short JSON would push the ladder into
+    probe/retry instead of the deliberate stop that guard_exit signals."""
+    state.update(
+        codex_exit=-1,
+        watchdog_fired=False,
+        session_id="",
+        report_exists=False,
+        report_copied=False,
+        worktree_touched=False,
+        tokens_used=0,
+        wall_seconds=0,
+        total_wall_seconds=-1,
+        log_tail="",
+        rung_error=message,
+        guard_exit=code,
+    )
+    return emit(state, code)
+
+
 def tail(path: Path, lines: int = LOG_TAIL_LINES) -> str:
     if not path.exists():
         return ""
@@ -119,16 +140,14 @@ def main(argv: list[str]) -> int:
         except (ValueError, ProcessLookupError, PermissionError):
             pidfile.unlink(missing_ok=True)
         else:
-            state["error"] = f"pidfile guard: codex pid {pid} for arm {label} is still alive"
-            return emit(state, 13)
+            return emit_guard(state, f"pidfile guard: codex pid {pid} for arm {label} is still alive", 13)
 
     # First attempt owns the dispatch file and truncates the log; later
     # attempts reuse both so the session's full history stays in one place.
     (d / "reports").mkdir(parents=True, exist_ok=True)
     if a.attempt == 1 or not dispatch.exists():
         if not a.brief:
-            state["error"] = "dispatch guard: --brief is required to write the dispatch file"
-            return emit(state, 12)
+            return emit_guard(state, "dispatch guard: --brief is required to write the dispatch file", 12)
         preamble = (
             f"Dispatch preamble (run tag {a.run_tag}): your working root is "
             f"{a.worktree}. Your report path is {report}. The brief follows."
@@ -143,11 +162,12 @@ def main(argv: list[str]) -> int:
     # instead of silently running another arm's task.
     text = dispatch.read_text(errors="replace")
     if a.worktree not in text or str(report) not in text:
-        state["error"] = (
+        return emit_guard(
+            state,
             f"dispatch guard: {dispatch} does not name worktree {a.worktree} "
-            f"and report path {report}"
+            f"and report path {report}",
+            12,
         )
-        return emit(state, 12)
 
     if a.resume_session:
         cmd = [a.codex_bin, "exec", "resume", a.resume_session, "-o", str(last_msg), "-"]
@@ -182,8 +202,7 @@ def main(argv: list[str]) -> int:
                 rc = 137
     except FileNotFoundError:
         pidfile.unlink(missing_ok=True)
-        state["error"] = f"codex binary not found: {a.codex_bin}"
-        return emit(state, 14)
+        return emit_guard(state, f"codex binary not found: {a.codex_bin}", 14)
     finally:
         pidfile.unlink(missing_ok=True)
 

--- a/.claude/workflows/bake-off/tests/test_run_codex_arm.py
+++ b/.claude/workflows/bake-off/tests/test_run_codex_arm.py
@@ -129,11 +129,16 @@ def test_resume_after_watchdog(env):
     assert "--- attempt 1 (initial) ---" in log and "--- attempt 2 (resume) ---" in log
 
 
+REQUIRED_RUNG_FIELDS = {"codex_exit", "session_id", "report_exists", "worktree_touched", "log_tail"}
+
+
 def test_dispatch_guard_trips_on_mispaired_dispatch(env):
     (env["dir"] / "dispatch-X.md").write_text("some other arm's dispatch\n")
     code, s = run(env, "--attempt", "2")
     assert code == 12
-    assert "dispatch guard" in s["error"]
+    assert s["guard_exit"] == 12 and "dispatch guard" in s["rung_error"]
+    assert REQUIRED_RUNG_FIELDS <= s.keys()  # guard JSON still satisfies the rung schema
+    assert s["codex_exit"] == -1 and s["session_id"] == ""
 
 
 def test_pidfile_guard_refuses_live_process(env):
@@ -142,7 +147,8 @@ def test_pidfile_guard_refuses_live_process(env):
     try:
         code, s = run(env)
         assert code == 13
-        assert "pidfile guard" in s["error"]
+        assert s["guard_exit"] == 13 and "pidfile guard" in s["rung_error"]
+        assert REQUIRED_RUNG_FIELDS <= s.keys()
     finally:
         p.kill()
         p.wait()

--- a/.claude/workflows/bake-off/tests/test_run_codex_arm.py
+++ b/.claude/workflows/bake-off/tests/test_run_codex_arm.py
@@ -1,0 +1,163 @@
+"""Tests for run_codex_arm.py against a fake `codex` binary.
+
+The stub's behavior is selected via FAKE_CODEX_MODE: success (writes the -o
+file and exits 0), hang (prints a session id then sleeps past any watchdog),
+fail-launch (transport-style failure: exit 1, no session id). A `resume`
+subcommand always completes successfully.
+
+Run: uvx pytest .claude/workflows/bake-off/tests/ -q
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+RUNNER = Path(__file__).resolve().parent.parent / "run_codex_arm.py"
+
+STUB = r'''#!/usr/bin/env python3
+import os, sys, time
+mode = os.environ.get("FAKE_CODEX_MODE", "success")
+args = sys.argv[1:]
+sys.stdin.read()
+out = args[args.index("-o") + 1]
+if "resume" in args:
+    print("session id: resumed0-dead-beef-0000-000000000000")
+    open(out, "w").write("resumed final message report\n")
+    print("tokens used: 4321")
+    sys.exit(0)
+if mode == "fail-launch":
+    print("stream error: HTTP 520")
+    sys.exit(1)
+print("session id: deadbeef-0000-0000-0000-000000000000", flush=True)
+if mode == "hang":
+    time.sleep(300)
+    sys.exit(0)
+open(out, "w").write("arm final message report\n")
+print("tokens used: 1234")
+sys.exit(0)
+'''
+
+
+@pytest.fixture()
+def env(tmp_path):
+    """A run dir, a tiny git worktree at a base commit, a brief, and the stub."""
+    d = tmp_path / "run"
+    d.mkdir()
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=wt, check=True)
+    subprocess.run(["git", "-C", str(wt), "config", "user.email", "t@t"], check=True)
+    subprocess.run(["git", "-C", str(wt), "config", "user.name", "t"], check=True)
+    (wt / "f.txt").write_text("base\n")
+    subprocess.run(["git", "-C", str(wt), "add", "f.txt"], check=True)
+    subprocess.run(["git", "-C", str(wt), "commit", "-qm", "base"], check=True)
+    base = subprocess.run(
+        ["git", "-C", str(wt), "rev-parse", "HEAD"], capture_output=True, text=True
+    ).stdout.strip()
+    brief = tmp_path / "brief.md"
+    brief.write_text("# Brief\ndo the thing\n")
+    stub = tmp_path / "codex"
+    stub.write_text(STUB)
+    stub.chmod(0o755)
+    return {"dir": d, "wt": wt, "base": base, "brief": brief, "stub": stub}
+
+
+def run(env_, *extra, mode="success", watchdog=30):
+    cmd = [
+        sys.executable, str(RUNNER),
+        "--dir", str(env_["dir"]), "--worktree", str(env_["wt"]),
+        "--label", "X", "--model", "fake-model", "--effort", "low",
+        "--base", env_["base"], "--brief", str(env_["brief"]),
+        "--watchdog-seconds", str(watchdog), "--codex-bin", str(env_["stub"]),
+        *extra,
+    ]
+    e = dict(os.environ, FAKE_CODEX_MODE=mode)
+    r = subprocess.run(cmd, capture_output=True, text=True, env=e, timeout=120)
+    state = json.loads(r.stdout.strip().splitlines()[-1]) if r.stdout.strip() else {}
+    return r.returncode, state
+
+
+def test_clean_pass(env):
+    code, s = run(env)
+    assert code == 0
+    assert s["codex_exit"] == 0 and s["watchdog_fired"] is False
+    assert s["kind"] == "initial" and s["attempt"] == 1
+    assert s["session_id"] == "deadbeef-0000-0000-0000-000000000000"
+    assert s["report_exists"] is True and s["report_copied"] is True
+    assert s["tokens_used"] == 1234
+    assert s["worktree_touched"] is False
+    log = (env["dir"] / "X.exec.log").read_text()
+    assert "CODEX_EXIT=0" in log
+    ladder = (env["dir"] / "X.ladder.jsonl").read_text().splitlines()
+    assert len(ladder) == 1 and json.loads(ladder[0])["codex_exit"] == 0
+    assert (env["dir"] / "X.start").exists() and (env["dir"] / "X.end").exists()
+
+
+def test_watchdog_kill(env):
+    t0 = time.time()
+    code, s = run(env, mode="hang", watchdog=2)
+    assert code == 0
+    assert s["watchdog_fired"] is True and s["codex_exit"] == 137
+    assert s["session_id"] == "deadbeef-0000-0000-0000-000000000000"
+    assert s["report_exists"] is False
+    assert time.time() - t0 < 60  # killed by watchdog, not by test timeout
+
+
+def test_launch_failure_leaves_clean_state(env):
+    code, s = run(env, mode="fail-launch")
+    assert code == 0
+    assert s["codex_exit"] == 1
+    assert s["session_id"] == ""  # nothing to resume — fresh-retry territory
+    assert s["worktree_touched"] is False and s["report_exists"] is False
+
+
+def test_resume_after_watchdog(env):
+    run(env, mode="hang", watchdog=2)
+    code, s = run(env, "--attempt", "2", "--resume-session",
+                  "deadbeef-0000-0000-0000-000000000000")
+    assert code == 0
+    assert s["kind"] == "resume" and s["codex_exit"] == 0
+    assert s["report_exists"] is True
+    ladder = (env["dir"] / "X.ladder.jsonl").read_text().splitlines()
+    assert len(ladder) == 2
+    log = (env["dir"] / "X.exec.log").read_text()
+    assert "--- attempt 1 (initial) ---" in log and "--- attempt 2 (resume) ---" in log
+
+
+def test_dispatch_guard_trips_on_mispaired_dispatch(env):
+    (env["dir"] / "dispatch-X.md").write_text("some other arm's dispatch\n")
+    code, s = run(env, "--attempt", "2")
+    assert code == 12
+    assert "dispatch guard" in s["error"]
+
+
+def test_pidfile_guard_refuses_live_process(env):
+    p = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
+    (env["dir"] / "X.pid").write_text(str(p.pid))
+    try:
+        code, s = run(env)
+        assert code == 13
+        assert "pidfile guard" in s["error"]
+    finally:
+        p.kill()
+        p.wait()
+
+
+def test_pidfile_guard_clears_dead_pid(env):
+    p = subprocess.Popen([sys.executable, "-c", "pass"])
+    p.wait()
+    (env["dir"] / "X.pid").write_text(str(p.pid))
+    code, s = run(env)
+    assert code == 0 and s["codex_exit"] == 0
+
+
+def test_worktree_touched_detected(env):
+    (env["wt"] / "new.txt").write_text("dirty\n")
+    code, s = run(env)
+    assert code == 0
+    assert s["worktree_touched"] is True


### PR DESCRIPTION
Implements `agents-config-9k9.217.5`. The m2 GPT round lost three of nine arms to a prose-interpreted recovery ladder: haiku wrappers skipped the resume protocol 3/3 times, and one hijacked a sibling arm's command line. This PR removes every recovery decision from model judgment.

## What changed

- **`run_codex_arm.py`** (new, beside `bake-off.js`): executes exactly one codex attempt — writes the dispatch with a self-check guard (refuses a dispatch not naming its own worktree + report path, exit 12), pidfile liveness guard (exit 13), in-code watchdog strictly below the rung's Bash timeout, state JSON on stdout, per-attempt append to `<label>.ladder.jsonl`.
- **`bake-off.js`**: the prose Step-1b ladder and `WRAPPER_SCHEMA` are gone. `runCodexLadder()` decides resume / one fresh retry (only on launch-level failure with a provably untouched worktree) / stop in plain JS from rung state; a dead or garbled transport agent triggers a disk probe that reconstructs the rung and the ladder continues; a live orphaned codex process stops the ladder rather than racing it. New args: `runnerPath` (required for codex arms), `maxAttempts`, `watchdogSeconds`, `rungTimeoutMs`.
- **Observability**: per-arm `ladder {outcome, attempts, resumed, history[]}` in the workflow result, on disk in the run dir, and narrated via `log()`. Deliberately absent from `gateSummary` and every judge prompt — a retry count is a bias vector and an unblinding hint. Judge-side codex prompt untouched (AC8).

## Evidence

- Unit: `uvx pytest .claude/workflows/bake-off/tests/ -q` → **8 passed** (fake-codex stub: clean pass, watchdog kill, transport failure, resume, both guards, dead-pid clearing, touched-worktree detection).
- Live smoke (AC7): run `wf_6564756b-d7f` — one luna-low arm on the real 9k9.75 brief, watchdog 180s vs a ~7-minute task, so success required scripted resumes. Ladder: `completed, 3 attempts, 2 resumes` (137/watchdog → 137/watchdog → 0 with report), one session id throughout, history identical in result and `SM.ladder.jsonl`.
- The three rung Bash calls ran at `timeout: 900000` — accepted, confirming the repo's `BASH_MAX_TIMEOUT_MS=1800000` reaches workflow subagents (docs are silent on this).

## Observed during the smoke, not defects in this change

- The smoke arm's gate went red (content-tests, exit 2): the watchdog SIGKILL mid-uv-run stranded an in-tree `.uv-cache` that content-tests discovery then swept (105 vendored suites). Filed with triage as `agents-config-9k9.222`; m2 worktrees at the same base carry no such cache and their gates passed.
- The codex sandbox could not create the worktree's `index.lock`, so the arm's work was audit-committed — the framework's existing fallback for exactly this.
- The transport agent's returned copy of attempt 1 dropped two optional fields; the on-disk ladder record (authoritative by design) is complete and correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DaXES6cVMwC2dhc875o3e