### PR TITLE
feat(9k9.223): named teammates deliver reports through a gated SendMessage protocol

### DIFF
--- a/src/user/.agents/skills/instructing-subagents/SKILL.md
+++ b/src/user/.agents/skills/instructing-subagents/SKILL.md
@@ -48,10 +48,14 @@ verifies them.
 **5. Reporting contract.** Say what the report must contain — evidence per criterion,
 what was changed or produced, conclusions reached and how they were verified, anything
 left undone or uncertain. Then command delivery twice: name a file
-path the agent *writes* the report to, and separately instruct — *send this report as
-your final message; do not end your turn without it.* A "report back with…" list
-describes an artifact and commands no action; agents finish, go idle, and deliver
-nothing while holding a good report. Code survives that; judgement does not.
+path the agent *writes* the report to, and separately command the send as an explicit
+act — where the harness has an agent-messaging tool, *deliver the report by calling
+it; text composed as a plain final message may never be transmitted.* Prefix progress
+messages `UPDATE <n>:` and the deliverable `FINAL REPORT:` — the markers make
+delivery mechanically checkable, and delivery gates key on them where they run. A
+"report back with…" list describes an artifact and commands no action; agents finish,
+go idle, and deliver nothing while holding a good report. Code survives that;
+judgement does not.
 
 **Fail-fast cases.** Beyond the report on completion, name the task-specific conditions
 under which the agent must stop *mid-execution* and come back for clarification or help —
@@ -103,8 +107,9 @@ Acceptance criteria:
 - <condition>
 
 Report: write your report to <absolute path>, covering <contents: evidence per
-criterion, what changed or was produced, anything left undone>. Then send the full
-report as your final message — do not end your turn without it.
+criterion, what changed or was produced, anything left undone>. Then deliver it by
+calling the agent-messaging tool, message beginning "FINAL REPORT:" — a plain
+final message is not delivery. Do not end your turn before the send succeeds.
 
 Stop mid-task and come back for guidance — partial report, same path — if:
 - <task-specific fail-fast case, e.g. the cause traces outside your boundary>

--- a/src/user/.claude/hooks/teammate-report-gate.py
+++ b/src/user/.claude/hooks/teammate-report-gate.py
@@ -43,7 +43,10 @@ IDLE_BLOCK_LIMIT = 3
 
 NAME_RE = re.compile(r"[^A-Za-z0-9._-]")
 SLUG_RE = re.compile(r"[^A-Za-z0-9]")
-UPDATE_RE = re.compile(r"^\s*UPDATE", re.IGNORECASE)
+UPDATE_RE = re.compile(r"^\s*UPDATE\b", re.IGNORECASE)
+# Anchored, but tolerant of leading markdown decoration ("**FINAL REPORT:**",
+# "# FINAL REPORT") — a mid-sentence mention must not count as delivery.
+FINAL_RE = re.compile(r"^[\s*_#>~`-]*FINAL REPORT\b", re.IGNORECASE)
 
 
 def now() -> str:
@@ -104,7 +107,7 @@ def is_update(text: str) -> bool:
 
 
 def is_final_report(text: str) -> bool:
-    return "final report" in (text or "")[:200].lower()
+    return bool(FINAL_RE.match(text or ""))
 
 
 def read_stash(directory: Path, name: str) -> dict | None:

--- a/src/user/.claude/hooks/teammate-report-gate.py
+++ b/src/user/.claude/hooks/teammate-report-gate.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Teammate lifecycle hook: gate task completion and idle exit on a delivered report.
+
+A named teammate agent that composes its final report as a plain assistant
+message delivers nothing — only an explicit call to the SendMessage tool
+transmits content to the orchestrator, and the automatic idle notification
+carries no report of its own. Left ungated, a teammate can mark its work done
+and go idle having never sent anything the orchestrator can read.
+
+This hook watches the teammate lifecycle for events that carry a non-empty
+``teammate_name`` — TaskCompleted and TeammateIdle — and blocks each one until
+either a progress update or a final report has been observed going out
+through the SendMessage tool. TaskCompleted additionally passes once any
+update has been seen since the last completion, on the theory that a teammate
+mid-series of tasks is still reporting as it goes. Both blocks give up after a
+short bounded number of retries rather than wedging the teammate forever.
+Every other event — including both events without a ``teammate_name``, which
+covers classic auto-returning subagents, workflow subagents, and main
+sessions by construction — passes through untouched.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+STATE_ROOT_DEFAULT = Path("/tmp/claude/teammate-report-gate")
+
+DEFAULT_STATE = {
+    "updates_seen": 0,
+    "completed_count": 0,
+    "task_blocks": 0,
+    "idle_blocks": 0,
+    "final_delivered": False,
+}
+
+TASK_BLOCK_LIMIT = 2
+IDLE_BLOCK_LIMIT = 3
+
+NAME_RE = re.compile(r"[^A-Za-z0-9._-]")
+SLUG_RE = re.compile(r"[^A-Za-z0-9]")
+UPDATE_RE = re.compile(r"^\s*UPDATE", re.IGNORECASE)
+
+
+def now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def state_root() -> Path:
+    override = os.environ.get("TEAMMATE_REPORT_GATE_STATE_ROOT")
+    return Path(override) if override else STATE_ROOT_DEFAULT
+
+
+def project_slug(cwd: str) -> str:
+    return SLUG_RE.sub("-", cwd)
+
+
+def safe_name(name: str) -> str:
+    return NAME_RE.sub("_", name)
+
+
+def state_dir(payload: dict) -> Path:
+    cwd = str(payload.get("cwd") or "")
+    session_id = str(payload.get("session_id") or "")
+    return state_root() / project_slug(cwd) / session_id
+
+
+def load_state(path: Path) -> dict:
+    if not path.is_file():
+        return dict(DEFAULT_STATE)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return dict(DEFAULT_STATE)
+    if not isinstance(data, dict):
+        return dict(DEFAULT_STATE)
+    return {
+        "updates_seen": int(data.get("updates_seen", 0) or 0),
+        "completed_count": int(data.get("completed_count", 0) or 0),
+        "task_blocks": int(data.get("task_blocks", 0) or 0),
+        "idle_blocks": int(data.get("idle_blocks", 0) or 0),
+        "final_delivered": bool(data.get("final_delivered", False)),
+    }
+
+
+def save_state(path: Path, state: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state), encoding="utf-8")
+
+
+def log_decision(directory: Path, event: str, name: str | None, decision: str, **extra) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    record = {"ts": now(), "event": event, "name": name, "decision": decision, **extra}
+    with (directory / "decisions.jsonl").open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def is_update(text: str) -> bool:
+    return bool(UPDATE_RE.match(text or ""))
+
+
+def is_final_report(text: str) -> bool:
+    return "final report" in (text or "")[:200].lower()
+
+
+def read_stash(directory: Path, name: str) -> dict | None:
+    path = directory / f"{safe_name(name)}.stop.json"
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def sender_from_response(payload: dict) -> str | None:
+    tool_response = payload.get("tool_response")
+    routing = tool_response.get("routing") if isinstance(tool_response, dict) else None
+    if isinstance(routing, dict):
+        sender = routing.get("sender")
+        if isinstance(sender, str) and sender.strip():
+            return sender.strip()
+    agent_type = payload.get("agent_type")
+    if isinstance(agent_type, str) and agent_type.strip():
+        return agent_type.strip()
+    return None
+
+
+def message_from_input(payload: dict) -> str | None:
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return None
+    for key in ("message", "content"):
+        value = tool_input.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    return None
+
+
+def handle_post_tool_use(payload: dict) -> int:
+    if payload.get("tool_name") != "SendMessage":
+        return 0
+    name = sender_from_response(payload)
+    if name is None:
+        return 0
+    message = message_from_input(payload)
+    if message is None:
+        return 0
+    directory = state_dir(payload)
+    state_path = directory / f"{safe_name(name)}.json"
+    state = load_state(state_path)
+    # The UPDATE prefix wins: a progress message that merely mentions the final
+    # report ("UPDATE 3: final report next") must not disarm the idle gate.
+    if is_update(message):
+        state["updates_seen"] += 1
+        save_state(state_path, state)
+        log_decision(directory, "PostToolUse", name, "update-observed",
+                     updates_seen=state["updates_seen"])
+    elif is_final_report(message):
+        state["final_delivered"] = True
+        state["idle_blocks"] = 0
+        save_state(state_path, state)
+        log_decision(directory, "PostToolUse", name, "final-report-observed")
+    return 0
+
+
+def handle_subagent_stop(payload: dict) -> int:
+    agent_type = payload.get("agent_type")
+    transcript_path = payload.get("agent_transcript_path")
+    if not (isinstance(agent_type, str) and agent_type.strip()) or not transcript_path:
+        return 0
+    name = agent_type.strip()
+    last_message = payload.get("last_assistant_message", "") or ""
+    final_in_last = "final report" in last_message.lower()
+    directory = state_dir(payload)
+    stash_path = directory / f"{safe_name(name)}.stop.json"
+    directory.mkdir(parents=True, exist_ok=True)
+    stash_path.write_text(
+        json.dumps({"transcript_path": transcript_path, "final_in_last_message": final_in_last}),
+        encoding="utf-8",
+    )
+    log_decision(directory, "SubagentStop", name, "stashed", final_in_last_message=final_in_last)
+    return 0
+
+
+def handle_task_completed(payload: dict, name: str) -> int:
+    directory = state_dir(payload)
+    state_path = directory / f"{safe_name(name)}.json"
+    state = load_state(state_path)
+    if state["final_delivered"] or state["updates_seen"] > state["completed_count"]:
+        state["completed_count"] += 1
+        state["task_blocks"] = 0
+        save_state(state_path, state)
+        log_decision(directory, "TaskCompleted", name, "allow")
+        return 0
+    if state["task_blocks"] >= TASK_BLOCK_LIMIT:
+        state["completed_count"] += 1
+        state["task_blocks"] = 0
+        save_state(state_path, state)
+        log_decision(directory, "TaskCompleted", name, "allow-give-up")
+        return 0
+    state["task_blocks"] += 1
+    save_state(state_path, state)
+    log_decision(directory, "TaskCompleted", name, "block", task_blocks=state["task_blocks"])
+    sys.stderr.write(
+        f"send a progress update now by calling the SendMessage tool with a message beginning "
+        f"'UPDATE {state['updates_seen'] + 1}:' — or, if this was the last task, send the full "
+        "'FINAL REPORT:' message instead — then mark the task complete again.\n"
+    )
+    return 2
+
+
+def handle_teammate_idle(payload: dict, name: str) -> int:
+    directory = state_dir(payload)
+    state_path = directory / f"{safe_name(name)}.json"
+    state = load_state(state_path)
+    if state["final_delivered"]:
+        state["idle_blocks"] = 0
+        save_state(state_path, state)
+        log_decision(directory, "TeammateIdle", name, "allow")
+        return 0
+    stash = read_stash(directory, name)
+    if state["idle_blocks"] >= IDLE_BLOCK_LIMIT:
+        marker_path = directory / f"{safe_name(name)}.stop-noncompliance.marker"
+        directory.mkdir(parents=True, exist_ok=True)
+        marker_path.write_text(
+            json.dumps({
+                "ts": now(),
+                "name": name,
+                "idle_blocks": state["idle_blocks"],
+                "transcript_path": (stash or {}).get("transcript_path"),
+                "note": "the gate released the idle without a recognized FINAL REPORT — check "
+                        "the agent's transcript for a stranded report",
+            }),
+            encoding="utf-8",
+        )
+        log_decision(directory, "TeammateIdle", name, "release-noncompliant",
+                     idle_blocks=state["idle_blocks"])
+        return 0
+    state["idle_blocks"] += 1
+    save_state(state_path, state)
+    log_decision(directory, "TeammateIdle", name, "block", idle_blocks=state["idle_blocks"])
+    if stash is not None and stash.get("final_in_last_message"):
+        sys.stderr.write(
+            "the composed report was not transmitted and must be resent: call the SendMessage "
+            "tool addressed to your orchestrator with a message beginning 'FINAL REPORT:'.\n"
+        )
+    else:
+        sys.stderr.write(
+            "your composed text does NOT reach the orchestrator on its own — deliver the report "
+            "now by calling the SendMessage tool addressed to your orchestrator with a message "
+            "beginning 'FINAL REPORT:'.\n"
+        )
+    return 2
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return 0
+    if not isinstance(payload, dict):
+        return 0
+
+    event = payload.get("hook_event_name")
+    if event == "PostToolUse":
+        return handle_post_tool_use(payload)
+    if event == "SubagentStop":
+        return handle_subagent_stop(payload)
+
+    name = payload.get("teammate_name")
+    if not (isinstance(name, str) and name.strip()):
+        return 0
+    name = name.strip()
+
+    if event == "TaskCompleted":
+        return handle_task_completed(payload, name)
+    if event == "TeammateIdle":
+        return handle_teammate_idle(payload, name)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:  # noqa: BLE001 - a hook must never break the session
+        sys.exit(0)

--- a/src/user/.claude/hooks/teammate-report-gate_test.py
+++ b/src/user/.claude/hooks/teammate-report-gate_test.py
@@ -197,6 +197,23 @@ class TestObservers:
                    monkeypatch) == 0
         assert run(teammate_idle("a"), monkeypatch) == 2
 
+    def test_updated_prefix_is_not_an_update(self, monkeypatch):
+        assert run(send_message_event("UPDATED the files as asked", sender="b"),
+                   monkeypatch) == 0
+        assert run(task_completed("b"), monkeypatch) == 2
+
+    def test_a_mid_sentence_final_report_mention_does_not_disarm_the_idle_gate(
+        self, monkeypatch,
+    ):
+        assert run(send_message_event("Should the final report include the appendix?",
+                                      sender="c"), monkeypatch) == 0
+        assert run(teammate_idle("c"), monkeypatch) == 2
+
+    def test_a_decorated_final_report_marker_still_counts(self, monkeypatch):
+        assert run(send_message_event("**FINAL REPORT:** all tasks done", sender="d"),
+                   monkeypatch) == 0
+        assert run(teammate_idle("d"), monkeypatch) == 0
+
     def test_posttooluse_falls_back_to_agent_type_when_no_routing_sender(self, monkeypatch):
         payload = send_message_event("FINAL REPORT: shipped it", agent_type="xi")
         assert run(payload, monkeypatch) == 0

--- a/src/user/.claude/hooks/teammate-report-gate_test.py
+++ b/src/user/.claude/hooks/teammate-report-gate_test.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["pytest>=8"]
+# ///
+"""Tests for the teammate report gate hook.
+
+Run: uv run teammate-report-gate_test.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+GATE_PATH = HERE / "teammate-report-gate.py"
+
+
+def _load_gate():
+    spec = importlib.util.spec_from_file_location("teammate_report_gate", GATE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+gate = _load_gate()
+
+CWD = "/Users/x/proj"
+SESSION = "sess-1"
+
+
+@pytest.fixture(autouse=True)
+def isolated_state_root(tmp_path, monkeypatch):
+    root = tmp_path / "state"
+    monkeypatch.setenv("TEAMMATE_REPORT_GATE_STATE_ROOT", str(root))
+    return root
+
+
+def run(payload: dict, monkeypatch) -> int:
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+    return gate.main()
+
+
+def task_completed(name: str | None, cwd: str = CWD, session_id: str = SESSION) -> dict:
+    payload = {"hook_event_name": "TaskCompleted", "cwd": cwd, "session_id": session_id}
+    if name is not None:
+        payload["teammate_name"] = name
+    return payload
+
+
+def teammate_idle(name: str | None, cwd: str = CWD, session_id: str = SESSION) -> dict:
+    payload = {"hook_event_name": "TeammateIdle", "cwd": cwd, "session_id": session_id}
+    if name is not None:
+        payload["teammate_name"] = name
+    return payload
+
+
+def send_message_event(
+    message: str, sender: str | None = None, agent_type: str | None = None,
+    cwd: str = CWD, session_id: str = SESSION,
+) -> dict:
+    payload = {
+        "hook_event_name": "PostToolUse",
+        "tool_name": "SendMessage",
+        "tool_input": {"message": message},
+        "tool_response": {"routing": {"sender": sender}} if sender is not None else {},
+        "cwd": cwd, "session_id": session_id,
+    }
+    if agent_type is not None:
+        payload["agent_type"] = agent_type
+    return payload
+
+
+def subagent_stop_event(
+    agent_type: str | None = None, last_assistant_message: str = "",
+    transcript_path: str = "/tmp/transcript.jsonl", cwd: str = CWD, session_id: str = SESSION,
+) -> dict:
+    payload = {
+        "hook_event_name": "SubagentStop", "last_assistant_message": last_assistant_message,
+        "cwd": cwd, "session_id": session_id,
+    }
+    if agent_type is not None:
+        payload["agent_type"] = agent_type
+        payload["agent_transcript_path"] = transcript_path
+    return payload
+
+
+def state_dir(root: Path, cwd: str = CWD, session_id: str = SESSION) -> Path:
+    return root / gate.project_slug(cwd) / session_id
+
+
+class TestTaskCompletedGate:
+    def test_blocks_then_allows_after_an_update(self, monkeypatch, capsys):
+        name = "alpha"
+        assert run(task_completed(name), monkeypatch) == 2
+        assert "UPDATE" in capsys.readouterr().err
+        run(send_message_event("UPDATE 1: working on it", sender=name), monkeypatch)
+        assert run(task_completed(name), monkeypatch) == 0
+
+    def test_two_consecutive_blocks_then_gives_up_and_allows(self, monkeypatch):
+        name = "beta"
+        assert run(task_completed(name), monkeypatch) == 2
+        assert run(task_completed(name), monkeypatch) == 2
+        assert run(task_completed(name), monkeypatch) == 0
+
+    def test_final_report_satisfies_a_task_completed_with_no_updates(self, monkeypatch):
+        name = "gamma"
+        run(send_message_event("FINAL REPORT: everything shipped", sender=name), monkeypatch)
+        assert run(task_completed(name), monkeypatch) == 0
+
+    def test_missing_teammate_name_is_never_blocked(self, monkeypatch):
+        assert run(task_completed(None), monkeypatch) == 0
+        assert run(task_completed(None), monkeypatch) == 0
+        assert run(task_completed(None), monkeypatch) == 0
+
+
+class TestTeammateIdleGate:
+    def test_blocks_without_final_report_then_allows_after_one(self, monkeypatch, capsys):
+        name = "delta"
+        assert run(teammate_idle(name), monkeypatch) == 2
+        assert "FINAL REPORT" in capsys.readouterr().err
+        run(send_message_event("FINAL REPORT: all done here", sender=name), monkeypatch)
+        assert run(teammate_idle(name), monkeypatch) == 0
+
+    def test_three_idle_blocks_then_a_marker_is_written_and_idle_allowed(
+        self, monkeypatch, isolated_state_root
+    ):
+        name = "epsilon"
+        for _ in range(3):
+            assert run(teammate_idle(name), monkeypatch) == 2
+        assert run(teammate_idle(name), monkeypatch) == 0
+        marker = state_dir(isolated_state_root) / f"{name}.stop-noncompliance.marker"
+        assert marker.is_file()
+        data = json.loads(marker.read_text(encoding="utf-8"))
+        assert data["name"] == name
+        assert data["idle_blocks"] == 3
+
+    def test_missing_teammate_name_is_never_blocked(self, monkeypatch):
+        assert run(teammate_idle(None), monkeypatch) == 0
+        assert run(teammate_idle(None), monkeypatch) == 0
+        assert run(teammate_idle(None), monkeypatch) == 0
+        assert run(teammate_idle(None), monkeypatch) == 0
+
+    def test_stash_with_final_report_in_last_message_changes_the_wording(
+        self, monkeypatch, capsys
+    ):
+        name = "iota"
+        run(subagent_stop_event(agent_type=name, last_assistant_message=(
+            "FINAL REPORT: composed here but never sent"
+        )), monkeypatch)
+        assert run(teammate_idle(name), monkeypatch) == 2
+        err = capsys.readouterr().err
+        assert "resent" in err.lower()
+
+    def test_without_a_stash_the_reminder_is_generic(self, monkeypatch, capsys):
+        name = "kappa"
+        assert run(teammate_idle(name), monkeypatch) == 2
+        err = capsys.readouterr().err
+        assert "does not reach the orchestrator" in err.lower()
+
+    def test_a_stash_lookup_miss_is_fine(self, monkeypatch, capsys):
+        name = "lookup-miss"
+        assert run(teammate_idle(name), monkeypatch) == 2
+        err = capsys.readouterr().err
+        assert "does not reach the orchestrator" in err.lower()
+
+
+class TestObservers:
+    def test_posttooluse_never_exits_nonzero(self, monkeypatch):
+        assert run(send_message_event("just some chatter", sender="mu"), monkeypatch) == 0
+        assert run(
+            {"hook_event_name": "PostToolUse", "tool_name": "OtherTool",
+             "cwd": CWD, "session_id": SESSION}, monkeypatch
+        ) == 0
+
+    def test_subagentstop_never_exits_nonzero_anonymous_or_typed(self, monkeypatch):
+        assert run(subagent_stop_event(), monkeypatch) == 0
+        assert run(subagent_stop_event(agent_type="nu"), monkeypatch) == 0
+
+    def test_posttooluse_credits_routing_sender_over_agent_type(self, monkeypatch):
+        payload = send_message_event(
+            "FINAL REPORT: shipped it", sender="alpha", agent_type="some-type"
+        )
+        assert run(payload, monkeypatch) == 0
+        assert run(teammate_idle("alpha"), monkeypatch) == 0
+
+    def test_an_update_mentioning_the_final_report_is_not_a_final_report(self, monkeypatch):
+        assert run(send_message_event("UPDATE 3: nearly done, final report next", sender="a"),
+                   monkeypatch) == 0
+        assert run(teammate_idle("a"), monkeypatch) == 2
+
+    def test_posttooluse_falls_back_to_agent_type_when_no_routing_sender(self, monkeypatch):
+        payload = send_message_event("FINAL REPORT: shipped it", agent_type="xi")
+        assert run(payload, monkeypatch) == 0
+        assert run(teammate_idle("xi"), monkeypatch) == 0
+
+    def test_posttooluse_with_neither_sender_nor_agent_type_is_a_no_op(self, monkeypatch):
+        payload = send_message_event("FINAL REPORT: shipped it")
+        assert run(payload, monkeypatch) == 0
+
+
+class TestStatePlacement:
+    def test_project_slug_matches_the_projects_directory_convention(self):
+        assert gate.project_slug("/Users/x/proj") == "-Users-x-proj"
+
+    def test_state_file_lands_under_slugged_cwd_and_session_id(
+        self, monkeypatch, isolated_state_root
+    ):
+        name = "theta"
+        run(task_completed(name), monkeypatch)
+        assert (state_dir(isolated_state_root) / f"{name}.json").is_file()
+
+
+class TestMalformedInput:
+    def test_unparseable_stdin_exits_zero(self, monkeypatch):
+        monkeypatch.setattr(sys, "stdin", io.StringIO("not json at all"))
+        assert gate.main() == 0
+
+    def test_a_json_scalar_is_not_a_payload(self, monkeypatch):
+        monkeypatch.setattr(sys, "stdin", io.StringIO("42"))
+        assert gate.main() == 0
+
+
+class TestNoPlanningJargon:
+    def test_the_deployed_hook_carries_no_planning_jargon(self):
+        jargon = re.compile(
+            r"\bD[0-9]|\bAC[0-9]|\bslice\b|\bcharter\b|\bmilestone\b|\bagents-config-9k9",
+            re.IGNORECASE,
+        )
+        hits = [
+            line for line in GATE_PATH.read_text(encoding="utf-8").splitlines()
+            if jargon.search(line)
+        ]
+        assert not hits, hits
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/src/user/.claude/rules/delegation.md
+++ b/src/user/.claude/rules/delegation.md
@@ -59,4 +59,7 @@ it warrants no reply — do not explain the notification or restate the report.
 <instructions-to-subagents>
 A subagent inherits none of your intent, and a vague dispatch returns noise you have to
 redo yourself. Read the `instructing-subagents` skill before you dispatch.
+A named teammate delivers only through an explicit SendMessage call — its plain final
+message reaches no one. Read the `orchestrating-teammates` skill when running named
+teammates and when one goes idle without a FINAL REPORT message.
 </instructions-to-subagents>

--- a/src/user/.claude/settings.json.template
+++ b/src/user/.claude/settings.json.template
@@ -41,6 +41,16 @@
             "timeout": 15
           }
         ]
+      },
+      {
+        "matcher": "SendMessage",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/teammate-report-gate.py",
+            "timeout": 10
+          }
+        ]
       }
     ],
     "SessionStart": [
@@ -60,6 +70,39 @@
           {
             "type": "command",
             "command": "python3 ~/.claude/hooks/codex-broker-reaper.py",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "TaskCompleted": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/teammate-report-gate.py",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "TeammateIdle": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/teammate-report-gate.py",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/teammate-report-gate.py",
             "timeout": 10
           }
         ]

--- a/src/user/.claude/skills/orchestrating-teammates/SKILL.md
+++ b/src/user/.claude/skills/orchestrating-teammates/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: orchestrating-teammates
+description: Use when running named teammate subagents and deciding what their silence means — a teammate's idle notification arrived but no FINAL REPORT message did, a report's delivery status is unclear, a stop-noncompliance marker or report-gate state directory needs reading, or you are about to ping, re-spawn, or give up on a quiet teammate. This skill owns diagnosing the silence, including the idle-without-report case instructing-subagents also lists; that skill governs only writing or rewriting the dispatch brief.
+admission:
+  prevents: An orchestrator mishandling a silent named teammate — repeated pings that return only further idle notifications, prose deliverables lost although composed verbatim in the teammate's own transcript, and delivery decisions blocked on a report that was never going to arrive.
+  cost: Accurate only while the teammate-report-gate hook ships in the deployed settings — edit or retire the two together.
+  remove_when: The harness delivers a teammate's report with its idle notification (or otherwise guarantees message-content delivery), or the teammate-report-gate hook is retired.
+---
+
+# Orchestrating Teammates
+
+Two mechanical facts govern everything here:
+
+- A named teammate transmits content **only by an explicit SendMessage tool call**.
+  Text it composes as a plain final message is never delivered anywhere. The
+  automatic idle notification is a separate event that carries no content and says
+  nothing about whether a report was sent — a teammate can believe it reported and
+  be wrong.
+- Delivery therefore leaves observable traces, and silence is investigated through
+  them — not by asking the teammate.
+
+## Dispatch
+
+Write the brief per `instructing-subagents`. The reporting contract MUST command
+delivery as a SendMessage call carrying the markers — progress messages beginning
+`UPDATE <n>:`, the deliverable beginning `FINAL REPORT:` — plus the written report
+file. The `teammate-report-gate` hook enforces exactly this protocol when wired in
+settings (`TaskCompleted`, `TeammateIdle`, `PostToolUse` on SendMessage): a task
+completion is refused until an UPDATE is sent, idle is refused until the FINAL
+REPORT is sent, and after three refused idles the teammate is released and a
+noncompliance marker is dropped for you to find.
+
+## When an idle notification arrives
+
+If the FINAL REPORT already reached you, the trailing idle notification warrants no
+reply. Otherwise investigate before touching the teammate, in this order:
+
+1. **Gate state**: `/tmp/claude/teammate-report-gate/<project-dir-slug>/<session-id>/`
+   (slug = cwd with every non-alphanumeric character replaced by `-`). Read
+   `<name>.json` — `final_delivered` settles whether a report was ever sent — and
+   `<name>.stop-noncompliance.marker`, which means the gate gave up and points at
+   the transcript.
+2. **The mandated report file** from the brief.
+3. **The teammate's own transcript**:
+   `~/.claude/projects/<project-dir-slug>/<parent-session-id>/subagents/agent-*.jsonl`.
+   A stranded report is usually composed there verbatim in the final assistant
+   turns — lift it; never re-spawn an agent to regenerate a report that already
+   exists on disk.
+4. **The tree itself**, for code work: `git status`, the diff, and the gate's own
+   exit status outrank any self-report.
+
+Ping at most once, and only for judgment the transcript cannot answer — choices it
+made, coverage it dropped deliberately. Command the reply as a SendMessage call
+beginning `FINAL REPORT:`; a ping recovers content only when the teammate replies
+through the tool. A second silent idle means stop pinging — `TaskStop` it and
+proceed on what the traces gave you.
+
+## Prose-only deliverables
+
+A review or critique teammate's only deliverable IS the report — there is no tree
+to fall back on. Never let a delivery decision wait on that report arriving:
+mandate the report file at dispatch, treat the SendMessage as confirmation, and
+when it goes quiet start at the transcript, where the judgment usually survives.


### PR DESCRIPTION
## Summary

A named teammate subagent that composes its final report as a plain assistant message delivers nothing: only an explicit `SendMessage` tool call transmits content, and the automatic idle notification carries no report. A transcript survey (2026-07-30 → 08-13, 201 named dispatches) measured the damage: of 170 dispatches that went idle, 23 (14%) were pinged and never delivered anything — a total loss when the deliverable is prose. Live experiments confirmed both the failure mechanism and the cure: an exit-2 hook gate recovered a deliberately stranded report in ~10s, and hooks alone induced the full update-plus-final-report protocol on an agent given no reporting instructions.

This PR ships the enforcement and the convention together (`agents-config-9k9.223`, track `pipeline-discipline`):

- **`src/user/.claude/hooks/teammate-report-gate.py`** — `TaskCompleted` refuses a completion until an `UPDATE n:` SendMessage goes out (2 refusals, then yields); `TeammateIdle` refuses idle until the `FINAL REPORT:` does (3 refusals, then releases and drops an orchestrator-visible `.stop-noncompliance.marker`); `PostToolUse` observes SendMessage traffic (crediting by `tool_response.routing.sender`, which stays correct for custom-typed teammates where `agent_type` carries the type); `SubagentStop` stashes `last_assistant_message` so the idle reminder can say "your composed report was not transmitted — resend it". State lives under `/tmp/claude/teammate-report-gate/<project-dir-slug>/<session-id>/`. Gates key on `teammate_name` presence, so classic auto-returning subagents, workflow subagents, and main sessions are never gated — `SubagentStop` cannot make that distinction, which is why it only observes.
- **`teammate-report-gate_test.py`** — paired suite, 21 tests, including the ordering defect caught in review (an UPDATE that merely mentions "final report" must not disarm the idle gate).
- **`settings.json.template`** — wires the four events; union-merge extends existing user settings.
- **`instructing-subagents` (shared tree)** — the reporting contract now commands delivery as an explicit send action with the `UPDATE <n>:` / `FINAL REPORT:` markers; the old "send this report as your final message" phrasing appears verbatim in a stranding dispatch in the survey.
- **`orchestrating-teammates` (new Claude-only skill, admit-request: ADMIT)** — the orchestrator side: what teammate silence means, the investigation order (gate state → report file → the teammate's own transcript → the tree), ping-once-then-TaskStop.
- **`delegation.md`** — three pointer lines.

## Verification

- `uv run --script teammate-report-gate_test.py`: 21 passed
- `make content-tests`, `make content-lint`, `make doc-lint`: all exit 0 from the worktree root
- `ruff check` clean on the hook; settings template parses (`python3 -m json.tool`)
- Trigger eval (18 should/should-not queries) run on the new skill's description; the one collision found (idle-without-report also listed by instructing-subagents) resolved with an ownership clause

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjNNdcRGMvN1CdpJrHUBEh