### PR TITLE
fix(9k9.125.1): reaper record protection requires endpoint corroboration, not bare pid

### DIFF
--- a/src/user/.claude/hooks/codex-broker-reaper.py
+++ b/src/user/.claude/hooks/codex-broker-reaper.py
@@ -11,9 +11,13 @@ no idle timeout, so it holds itself and its child until the machine restarts.
 
 A broker is only terminated here when both proofs hold:
 
-  1. No `broker.json` under any state root names its pid. `broker.json` is the
-     sole route to a broker — nothing sets the endpoint environment variable —
-     so a pid absent from every record is unreachable by construction.
+  1. No `broker.json` under any state root names both its pid and its own
+     endpoint socket. `broker.json` is the sole route to a broker — nothing
+     sets the endpoint environment variable — so a record naming neither is
+     unreachable by construction. Pid alone is not enough: pids recycle, and a
+     record long dead can still name the pid a live, unrelated broker now
+     holds. The endpoint is the part that can't coincide by accident, so a
+     record only protects the broker whose live socket it actually names.
   2. Nothing is connected to its socket. A listening socket with no peer shows
      one holder; each connected client adds one. This matters because a broker
      that lost the race is still handed back to the caller that spawned it, in
@@ -140,13 +144,19 @@ def state_roots() -> list[Path]:
     return unique
 
 
-def referenced_pids(roots: list[Path]) -> set[int]:
-    """Every broker pid named by a session record. These are reachable."""
-    pids = set()
+def referenced_sockets(roots: list[Path]) -> dict[int, set[str | None]]:
+    """Every (pid, endpoint socket) pair named by a session record.
+
+    Keyed by pid rather than a flat pair set so a lookup by a live broker's
+    pid is O(1) instead of a scan. A bare pid is not proof of reachability —
+    pids recycle — so callers must also check the live broker's own socket
+    against this pid's recorded set before trusting the record.
+    """
+    by_pid: dict[int, set[str | None]] = {}
     for root in roots:
         for record in root.glob("*/broker.json"):
             try:
-                pid = json.loads(record.read_text(encoding="utf8")).get("pid")
+                data = json.loads(record.read_text(encoding="utf8"))
             except (OSError, ValueError):
                 # A record that will not parse confers no reachability. The
                 # plugin loads these the same way and treats a parse failure as
@@ -159,9 +169,16 @@ def referenced_pids(roots: list[Path]) -> set[int]:
                 # written within milliseconds of a spawn, and nothing rewrites
                 # one later, so the minimum-age gate already covers that window.
                 continue
-            if isinstance(pid, int):
-                pids.add(pid)
-    return pids
+            pid = data.get("pid")
+            if not isinstance(pid, int):
+                continue
+            endpoint = data.get("endpoint")
+            # Same unix-prefix transform as endpoint_socket() applies to a live
+            # process's cmdline, so a record's value compares equal to what a
+            # live broker's own socket resolves to.
+            socket_path = endpoint[len("unix:") :] if isinstance(endpoint, str) and endpoint.startswith("unix:") else None
+            by_pid.setdefault(pid, set()).add(socket_path)
+    return by_pid
 
 
 def socket_holders(socket_path: str) -> int | None:
@@ -181,8 +198,8 @@ def is_group_leader(pid: int) -> bool:
         return False
 
 
-def should_reap(broker: dict, referenced: set[int]) -> tuple[bool, str]:
-    if broker["pid"] in referenced:
+def should_reap(broker: dict, referenced: dict[int, set[str | None]]) -> tuple[bool, str]:
+    if broker["socket"] in referenced.get(broker["pid"], ()):
         return False, "named by a session record"
     if broker["age"] < min_age_seconds():
         return False, "too young to judge"
@@ -240,7 +257,7 @@ def main(argv: list[str] | None = None) -> int:
             pass
 
     brokers = live_brokers()
-    referenced = referenced_pids(state_roots())
+    referenced = referenced_sockets(state_roots())
 
     reaped = []
     for broker in brokers:

--- a/src/user/.claude/hooks/codex-broker-reaper.py
+++ b/src/user/.claude/hooks/codex-broker-reaper.py
@@ -13,8 +13,8 @@ A broker is only terminated here when both proofs hold:
 
   1. No `broker.json` under any state root names both its pid and its own
      endpoint socket. `broker.json` is the sole route to a broker — nothing
-     sets the endpoint environment variable — so a record naming neither is
-     unreachable by construction. Pid alone is not enough: pids recycle, and a
+     sets the endpoint environment variable — so a broker no record names
+     this way is unreachable by construction. Pid alone is not enough: pids recycle, and a
      record long dead can still name the pid a live, unrelated broker now
      holds. The endpoint is the part that can't coincide by accident, so a
      record only protects the broker whose live socket it actually names.

--- a/src/user/.claude/hooks/codex-broker-reaper_test.sh
+++ b/src/user/.claude/hooks/codex-broker-reaper_test.sh
@@ -147,6 +147,21 @@ assert_contains "and says why"                             "named by a session r
 assert_missing  "recorded broker is never reaped"          "REAP $KEPT_PID" "$OUT"
 assert_alive    "recorded broker survives"                 "$KEPT_PID"
 
+# --- a pid-only match from a stale record is not protection ------------------
+# macOS pids wrap at ~99,999. A record whose process died long ago can still
+# name the pid a live, unrelated broker now holds by coincidence. Simulated
+# here without waiting on the OS to actually recycle anything: a record naming
+# this broker's pid but a DIFFERENT (nonexistent) endpoint stands in for "a
+# dead process's record, which pointed at its own now-gone socket" — the pid
+# collides, nothing else does. Bare pid matching would spare this broker
+# forever; corroborating against the endpoint must not.
+start_stub recycled RECYCLED_PID RECYCLED_SOCK
+record_broker recycled-workspace "$RECYCLED_PID" "$WORK/stale-dead-brokers-own.sock"
+run_hook --verbose
+assert_contains "pid-recycled orphan is reaped despite the stale record" \
+  "REAP $RECYCLED_PID" "$OUT"
+assert_dead     "and is gone"                              "$RECYCLED_PID"
+
 # --- the other two state roots confer the same protection --------------------
 # Redirecting HOME and TMPDIR into this run costs the coverage those two roots
 # would otherwise get from the machine's own records, and a root the hook skips


### PR DESCRIPTION
Closes the reaper's growing-false-negative defect (agents-config-9k9.125.1): session records protected any live broker whose pid they named, and macOS pid recycling (wraps ~99,999; 356 of 357 recorded pids measured dead) meant a stale dead record could permanently spare an unrelated orphan broker.

A liveness check on the record's pid cannot catch this — in the failure case the pid IS alive, as the orphan itself. The fix corroborates each record against the endpoint socket it names: `referenced_pids()` becomes `referenced_sockets()` keyed by pid, and `should_reap()` treats a broker as record-protected only when both its pid and its live socket match a record.

- New test simulates the pid-recycled orphan (record names the broker's pid but a different, dead endpoint); red on unpatched (28 pass / 2 fail), green on patched (30 pass / 0 fail), mutation-checked (reverting the guard turns exactly the new test red).
- Existing protections unchanged: record naming a live pid + correct endpoint still protects; connected-client and min-age proofs untouched; unparseable-endpoint records degrade conservatively.
- Gates run standalone from the worktree root: content-tests EXIT=0 (14 suites), content-lint EXIT=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U59PwBh8cy2fTis8W3cBbo