### PR TITLE
fix(9k9.75): a review snapshot's lifetime ends with its PR cycle

### DIFF
--- a/packages/grind/src/grind/conditions.py
+++ b/packages/grind/src/grind/conditions.py
@@ -34,8 +34,9 @@ _TERMINAL_ITEM_STATUSES = {"merged", "done"}
 _CHAIN_BLOCKING_STATUSES = {"blocked", "waiting-human"}
 
 # Statuses with a live PR/review cycle -- the only place a review stalemate
-# can exist. round_history is fold history and survives the cycle, so
-# `review_stalemate_risk` must not read it once the item moves on.
+# can exist. Only the two closure paths clear round_history; every other way
+# out of a review leaves it standing, so `review_stalemate_risk` must not read
+# it once the item moves on.
 _ACTIVE_REVIEW_STATUSES = {"pr-open", "in-review", "waiting-human", "blocked"}
 
 _DURATION_RE = re.compile(r"^(\d+)([smhd])$")
@@ -230,10 +231,10 @@ def _review_stalemate_risk(state: State) -> list[Condition]:
     n = _int_threshold(state.config.get("stalemate_risk_round"), 3, minimum=1)
     out: list[Condition] = []
     for item in state.items.values():
-        # round_history survives the review cycle (it is fold history, never
-        # cleared), so gate on a live review state: a done/merged item, one
-        # whose PR closed and re-queued, or a parked item (parking preserves
-        # status), is not a stalemate however it got there
+        # A closure clears round_history, but a merge, a park and a second PR
+        # opened over a live one do not, so gate on a live review state: a
+        # done/merged item, one whose PR closed and re-queued, or a parked item
+        # (parking preserves status), is not a stalemate however it got there
         if item.status not in _ACTIVE_REVIEW_STATUSES or item.parked is not None:
             continue
         history = item.round_history

--- a/packages/grind/src/grind/fold.py
+++ b/packages/grind/src/grind/fold.py
@@ -387,6 +387,18 @@ def _record_round(item: Item, round_: int | None, head_sha: str | None, ts: str 
     item.round_history = (*item.round_history, (round_, head_sha, ts))
 
 
+def _clear_review_cycle(item: Item) -> None:
+    """Drop the review facts whose subject was the PR this closure just ended.
+
+    The snapshot and the round history supporting it share one lifetime, so
+    they end together: a projection that kept either would report a dead PR's
+    result against whatever the item does next. Called only once a closure has
+    passed its validity guards -- a refused closure ends no cycle.
+    """
+    item.review = ItemReview()
+    item.round_history = ()
+
+
 @_handler("review_round")
 def _h_review_round(state: State, evt: RawEvent) -> None:
     item = _active_item(state, evt)
@@ -475,10 +487,13 @@ def _h_pr_closed(state: State, evt: RawEvent) -> None:
     state.closed_ledger.append(
         ClosedEntry(item=item.id, pr=_int(evt, "pr"), reason=reason, ts=_str(evt, "ts"))
     )
-    # the review cycle ends with its PR: a later pr_opened starts a fresh
-    # cycle that must not inherit the closed PR's stalemate history, nor the
-    # fix budget spent on it -- the attempt ledger's lifetime is one PR cycle
-    item.round_history = ()
+    # The review cycle ends with its PR, on every `next` route including
+    # `parked`: the item must not carry the closed PR's verdict, thread counts
+    # or stalemate history into what it does next, nor the fix budget spent on
+    # it -- the attempt ledger's lifetime is one PR cycle too. What explains a
+    # park is the typed reason and the closure row below, not a dead PR's
+    # review result.
+    _clear_review_cycle(item)
     item.attempts = new_attempt_ledger()
     # The ref stays for the failure-axis park rule; marking it closed is what
     # keeps "has a PR ref" from being read as "has an open PR".
@@ -683,8 +698,9 @@ def _record_closure(state: State, item: Item, evt: RawEvent) -> None:
     The parking lot keeps its single exit: an abandoned item re-enters play
     exactly as any other does, and the closure only adds what abandonment
     means on top of that -- the ledger entry recording which PR closed and why,
-    and dropping the PR ref (with the review history belonging to it) so the
-    next cycle starts clean. `pr_closed` gains no new source state from this.
+    and dropping the PR ref (with the review snapshot and history belonging to
+    it) so the next cycle starts clean. `pr_closed` gains no new source state
+    from this.
 
     The PR named must be the one the item actually holds. The boundary can
     only check that `--pr` is an integer, so a mistyped number arrives
@@ -707,7 +723,7 @@ def _record_closure(state: State, item: Item, evt: RawEvent) -> None:
         ClosedEntry(item=item.id, pr=pr, reason=_str(closure, "reason"), ts=_str(evt, "ts"))
     )
     item.pr = None
-    item.round_history = ()
+    _clear_review_cycle(item)
 
 
 @_handler("item_enqueued")

--- a/packages/grind/src/grind/model.py
+++ b/packages/grind/src/grind/model.py
@@ -121,7 +121,16 @@ class PrRef:
 
 @dataclass
 class ItemReview:
-    """Typed review state -- the renderer must label/tooltip/iconify without parsing prose."""
+    """Typed review state for the current PR cycle -- the renderer must
+    label/tooltip/iconify without parsing prose.
+
+    Its subject is one pull request, so both closure paths clear it along with
+    the round history supporting it, and no projection attributes a closed
+    PR's result to what the item does next. Leaving it for the next cycle to
+    overwrite would not do: `review_round` writes only the first four fields,
+    so a retained verdict, its thread counts and its stalemate flag ride into
+    the new cycle's first round instead of being replaced by it.
+    """
 
     round: int | None = None
     kind: str | None = None  # codex | copilot | ralf | human
@@ -197,8 +206,10 @@ class Item:
     # round values ... all carry the SAME head_sha"), with each round's
     # authoritative event ts so the fired condition can report the window's
     # start (`since`). Recorded by the fold (facts copied from events), never
-    # itself a computed condition; cleared by `pr_closed` -- the history
-    # belongs to one PR cycle, a new PR must not inherit an old stalemate.
+    # itself a computed condition; cleared by both closure paths, `pr_closed`
+    # and `item_enqueued`'s closure -- the history belongs to one PR cycle, as
+    # does the review snapshot above, and a new PR must not inherit an old
+    # stalemate.
     round_history: tuple[tuple[int, str | None, str | None], ...] = ()
 
 

--- a/packages/grind/tests/unit/test_review_snapshot_lifetime.py
+++ b/packages/grind/tests/unit/test_review_snapshot_lifetime.py
@@ -1,0 +1,341 @@
+"""A review snapshot describes one PR cycle and does not outlive it.
+
+Every projection assertion here addresses the reviewed item by id. A read
+positioned by index would land on the second seeded item, which is never
+reviewed and whose review is therefore default under any implementation --
+an assertion that passes whatever the fold does.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Literal
+
+import pytest
+
+from grind.fold import fold
+from grind.handoff import handoff_json
+from grind.model import ItemReview, State
+from grind.render import render_dashboard
+from grind.serialize import full_state_json
+from tests.unit.builders import event, seed_event
+
+_ITEM = "wgclw.1"
+
+# What `status --full` and the handoff emit for an item carrying no review.
+_FULL_DEFAULT_REVIEW = {
+    "round": None,
+    "kind": None,
+    "head_sha": None,
+    "detail": None,
+    "verdict": None,
+    "open_threads": 0,
+    "wont_fix_count": 0,
+    "stalemate": False,
+}
+_HANDOFF_DEFAULT_REVIEW = {
+    "round": None,
+    "kind": None,
+    "verdict": None,
+    "open_threads": 0,
+    "stalemate": False,
+}
+
+
+def _reviewed_pr() -> list[dict[str, Any]]:
+    """PR 7 taken to a stalemate verdict -- every snapshot field populated.
+
+    A verdict, not a round alone: `review_round` writes four of the eight
+    fields, so the other four (verdict, both counts, the stalemate flag) are
+    only ever set here, and they are the ones a later round cannot overwrite.
+    """
+    return [
+        seed_event(),
+        event("item_started", item=_ITEM),
+        event("pr_opened", item=_ITEM, pr=7),
+        event(
+            "review_round",
+            item=_ITEM,
+            kind="codex",
+            round=3,
+            head_sha="old-head",
+            detail="two threads open on the closed PR",
+        ),
+        event(
+            "review_verdict",
+            item=_ITEM,
+            kind="codex",
+            round=3,
+            head_sha="old-head",
+            verdict="stalemate",
+            findings=[{"disposition": "deferred"}, {"disposition": "wont-fix"}],
+        ),
+    ]
+
+
+def _parked_reviewed_pr() -> list[dict[str, Any]]:
+    """The reviewed PR parked by `item_parked`, which closes no PR: the ref
+    survives, so the abandon exit below has a live PR 7 to name."""
+    return [
+        *_reviewed_pr(),
+        event("item_parked", item=_ITEM, reason="bot-declined", note="reviewer declined"),
+    ]
+
+
+def _dashboard_payload(state: State) -> dict[str, Any]:
+    html = render_dashboard(state)
+    start = html.index("var STATE = ") + len("var STATE = ")
+    end = html.index(";\n\nvar KNOWN_STATUSES", start)
+    payload: dict[str, Any] = json.loads(html[start:end])
+    return payload
+
+
+def _handoff_item(state: State) -> dict[str, Any]:
+    """The item's own handoff row, from a lane roster or the parking lot."""
+    payload = handoff_json(state)
+    rows: list[dict[str, Any]] = [item for lane in payload["lanes"] for item in lane["items"]]
+    rows.extend(payload["parking_lot"])
+    return next(row for row in rows if row["id"] == _ITEM)
+
+
+def _full_item(state: State) -> dict[str, Any]:
+    items = full_state_json(state)["items"]
+    assert isinstance(items, dict)
+    item: dict[str, Any] = items[_ITEM]
+    return item
+
+
+def _assert_no_review_attribution(state: State) -> None:
+    """No surface that reads the snapshot still reports the closed PR's review."""
+    assert state.items[_ITEM].review == ItemReview()
+    assert state.items[_ITEM].round_history == ()
+    assert _full_item(state)["review"] == _FULL_DEFAULT_REVIEW
+    assert _handoff_item(state)["review"] == _HANDOFF_DEFAULT_REVIEW
+
+    dashboard = _dashboard_payload(state)
+    cards = [card for lane in dashboard["lanes"] for card in lane["queue"] if card["id"] == _ITEM]
+    if cards:
+        assert cards[0]["review"] is None
+    else:
+        # Parking removes the item from its lane's queue, so the dashboard's
+        # only row for it is the parking-lot one -- which carries identity and
+        # park fields and no review key at all.
+        parked = [row for row in dashboard["parking_lot"] if row["id"] == _ITEM]
+        assert parked, "the item is on neither a lane card nor the parking lot"
+        assert "review" not in parked[0]
+
+
+@pytest.mark.parametrize("next_status", ["in-progress", "queued"])
+def test_pr_closed_back_to_work_ends_review_attribution_in_every_projection(
+    next_status: Literal["in-progress", "queued"],
+) -> None:
+    state = fold(
+        [
+            *_reviewed_pr(),
+            event("pr_closed", item=_ITEM, pr=7, reason="superseded", next=next_status),
+        ]
+    )
+
+    _assert_no_review_attribution(state)
+
+
+def test_an_abandon_closure_ends_review_attribution_in_every_projection() -> None:
+    state = fold(
+        [
+            *_parked_reviewed_pr(),
+            event(
+                "item_enqueued",
+                item=_ITEM,
+                lane="lane-a",
+                closure={"pr": 7, "reason": "abandoned"},
+            ),
+        ]
+    )
+
+    _assert_no_review_attribution(state)
+
+
+def test_the_ordinary_and_abandon_exits_agree_on_the_snapshot() -> None:
+    ordinary = fold(
+        [
+            *_reviewed_pr(),
+            event("pr_closed", item=_ITEM, pr=7, reason="superseded", next="queued"),
+        ]
+    )
+    abandoned = fold(
+        [
+            *_parked_reviewed_pr(),
+            event("item_enqueued", item=_ITEM, lane="lane-a", closure={"pr": 7}),
+        ]
+    )
+
+    assert ordinary.items[_ITEM].review == abandoned.items[_ITEM].review == ItemReview()
+    assert ordinary.items[_ITEM].round_history == abandoned.items[_ITEM].round_history == ()
+    assert _full_item(ordinary)["review"] == _full_item(abandoned)["review"]
+    assert _handoff_item(ordinary)["review"] == _handoff_item(abandoned)["review"]
+
+
+def test_pr_closed_to_parked_ends_attribution_and_keeps_the_park_evidence() -> None:
+    """The parked route ends the cycle like every other one.
+
+    What explains the park is the typed reason, its note and the closure row --
+    not the dead PR's review result, which is what the item would otherwise
+    carry back into play.
+    """
+    state = fold(
+        [
+            *_reviewed_pr(),
+            event("pr_closed", item=_ITEM, pr=7, reason="bot-declined", next="parked"),
+        ]
+    )
+
+    item = state.items[_ITEM]
+    assert item.parked is not None
+    assert (item.parked.reason, item.parked.note) == ("bot-declined", "bot-declined")
+    assert (item.parked.axis, item.parked.category) == ("failure", "human")
+    assert [(entry.pr, entry.reason) for entry in state.closed_ledger] == [(7, "bot-declined")]
+    # The ref outlives its PR so the failure-axis park keeps its subject.
+    assert item.pr is not None
+    assert (item.pr.number, item.pr.closed) == (7, True)
+    # The park evidence reaches the reader on the same row the stale review
+    # used to ride on.
+    assert _handoff_item(state)["parked"]["reason"] == "bot-declined"
+
+    _assert_no_review_attribution(state)
+
+
+def test_an_enqueue_without_a_closure_keeps_the_surviving_prs_review() -> None:
+    """Only a closure ends a cycle. An item parked with its PR still open
+    re-enters play on that same PR, and its review is current, not stale."""
+    parked = _parked_reviewed_pr()
+    preserved = fold([*parked, event("item_enqueued", item=_ITEM, lane="lane-a")])
+    ended = fold([*parked, event("item_enqueued", item=_ITEM, lane="lane-a", closure={"pr": 7})])
+
+    assert preserved.items[_ITEM].review == fold(parked).items[_ITEM].review
+    assert preserved.items[_ITEM].review.stalemate is True
+    assert preserved.items[_ITEM].round_history == fold(parked).items[_ITEM].round_history
+    assert preserved.items[_ITEM].pr is not None
+    assert ended.items[_ITEM].review == ItemReview()
+
+
+def test_an_enqueue_without_a_closure_does_not_revive_a_snapshot_already_ended() -> None:
+    """`pr_closed(next=parked)` already ended the cycle, so the plain enqueue
+    that follows has nothing to preserve -- the route back into active work
+    carries no closed PR's verdict with it."""
+    state = fold(
+        [
+            *_reviewed_pr(),
+            event("pr_closed", item=_ITEM, pr=7, reason="bot-declined", next="parked"),
+            event("item_enqueued", item=_ITEM, lane="lane-a"),
+        ]
+    )
+
+    assert state.items[_ITEM].status == "queued"
+    assert state.items[_ITEM].parked is None
+    _assert_no_review_attribution(state)
+
+
+def test_a_closure_the_fold_refuses_leaves_the_live_snapshot_alone() -> None:
+    """A closure naming a PR the item does not hold is recorded and not
+    applied, so it ends no cycle: the surviving PR keeps its review."""
+    parked = _parked_reviewed_pr()
+    refused = fold([*parked, event("item_enqueued", item=_ITEM, lane="lane-a", closure={"pr": 99})])
+    applied = fold([*parked, event("item_enqueued", item=_ITEM, lane="lane-a", closure={"pr": 7})])
+
+    assert refused.items[_ITEM].review == fold(parked).items[_ITEM].review
+    assert refused.items[_ITEM].round_history == fold(parked).items[_ITEM].round_history
+    assert refused.items[_ITEM].pr is not None
+    assert any("closure names PR 99" in a.reason for a in refused.anomalies)
+    assert applied.items[_ITEM].review == ItemReview()
+
+
+@pytest.mark.parametrize("exit_route", ["ordinary", "abandon"])
+def test_the_next_cycle_records_its_own_review_from_an_empty_snapshot(exit_route: str) -> None:
+    """The first round of a new cycle writes round, kind, head_sha and detail
+    and nothing else, so a leaked verdict or thread count from the previous
+    cycle is visible on the board until a verdict happens to overwrite it.
+    This is the state where that leak shows."""
+    if exit_route == "ordinary":
+        closed = [
+            *_reviewed_pr(),
+            event("pr_closed", item=_ITEM, pr=7, reason="superseded", next="in-progress"),
+        ]
+    else:
+        closed = [
+            *_parked_reviewed_pr(),
+            event("item_enqueued", item=_ITEM, lane="lane-a", closure={"pr": 7}),
+            event("item_started", item=_ITEM),
+        ]
+
+    opened = [
+        *closed,
+        event("pr_opened", item=_ITEM, pr=8),
+        event("review_round", item=_ITEM, kind="human", round=1, head_sha="new-head"),
+    ]
+    round_state = fold(opened)
+
+    assert round_state.items[_ITEM].review == ItemReview(round=1, kind="human", head_sha="new-head")
+    assert round_state.items[_ITEM].round_history == ((1, "new-head", "2026-07-19T00:05:00Z"),)
+
+    verdict_state = fold(
+        [
+            *opened,
+            event(
+                "review_verdict",
+                item=_ITEM,
+                kind="human",
+                round=1,
+                head_sha="new-head",
+                verdict="clean",
+                findings=[],
+            ),
+        ]
+    )
+
+    assert verdict_state.items[_ITEM].review == ItemReview(
+        round=1, kind="human", head_sha="new-head", verdict="clean"
+    )
+    assert verdict_state.anomalies == []
+
+
+@pytest.mark.parametrize("exit_route", ["ordinary", "abandon"])
+def test_both_closures_of_a_never_reviewed_pr_are_no_ops(exit_route: str) -> None:
+    never_reviewed = [
+        seed_event(),
+        event("item_started", item=_ITEM),
+        event("pr_opened", item=_ITEM, pr=7),
+    ]
+    if exit_route == "ordinary":
+        events = [
+            *never_reviewed,
+            event("pr_closed", item=_ITEM, pr=7, reason="superseded", next="queued"),
+        ]
+    else:
+        events = [
+            *never_reviewed,
+            event("item_parked", item=_ITEM, reason="bot-declined"),
+            event("item_enqueued", item=_ITEM, lane="lane-a", closure={"pr": 7}),
+        ]
+
+    state = fold(events)
+
+    assert state.items[_ITEM].review == ItemReview()
+    assert state.items[_ITEM].round_history == ()
+    assert state.anomalies == []
+
+
+def test_item_done_still_clears_the_snapshot() -> None:
+    """The merge path keeps its own clearing: a merged item holds its review
+    until `item_done`, which is the only place a *merged* cycle's snapshot is
+    dropped."""
+    merged = [
+        *_reviewed_pr(),
+        event("item_merged", item=_ITEM, pr=7, sha="old-head"),
+    ]
+
+    assert fold(merged).items[_ITEM].review.stalemate is True
+
+    done = fold([*merged, event("item_done", item=_ITEM)])
+
+    assert done.items[_ITEM].status == "done"
+    assert done.items[_ITEM].review == ItemReview()

--- a/packages/grind/tests/unit/test_review_snapshot_lifetime.py
+++ b/packages/grind/tests/unit/test_review_snapshot_lifetime.py
@@ -59,7 +59,7 @@ def _reviewed_pr() -> list[dict[str, Any]]:
             kind="codex",
             round=3,
             head_sha="old-head",
-            detail="two threads open on the closed PR",
+            detail="one thread deferred and one wont-fix on the closed PR",
         ),
         event(
             "review_verdict",


### PR DESCRIPTION
Fixes tracker item `agents-config-9k9.75` (grind review-snapshot staleness): `Item.review` was cleared only by `item_done`, so `status --full`, the handoff projection and the dashboard attributed a closed PR's review result to whatever the item did next — and the leak was not self-correcting, since `review_round` writes only four of the snapshot's eight fields, so a retained verdict, thread counts and stalemate flag rode into the new cycle's first round.

**The fix**: both cycle-ending events (`pr_closed` on every `next` route including `parked`, and `item_enqueued`'s validated closure) clear the snapshot together with `round_history` through one helper called after the existing validity guards. A refused closure ends nothing; a closure-less enqueue preserves a still-open PR's review. On the parked route, what explains a park is the typed `ParkingEntry` and the closure-ledger row — both verified to survive — not a dead PR's review result.

**Deliberately declined, with reasoning in the item trail**: archiving the ended snapshot onto `ClosedEntry` (out of item scope; changes a ledger shape `packages/executor` consumes; the event log already retains every verdict), and a `pr_opened`-time guard (the route is real but leaks three field families — review, history, and the `attempts` fix budget — and an unconditional clear would destroy a live review on a same-PR re-announcement; filed separately as `agents-config-9k9.224`).

**Evidence**
- 13 new tests; 10 red against the unmodified fold (red run performed on a pristine `git archive` copy with a measured control), 3 disclosed baseline-green no-op pins. Every projection assertion selects the item's row by id, never by bare index.
- Mutation check: removing either clear site, regressing the parked route, or deleting `item_done`'s reset each fails the suite; unmutated control 398 passed.
- Every snapshot consumer measured before/after: `full_state_json`, handoff rows (lanes and parking lot), dashboard cards updated; parking/ledger/conditions/executor surfaces shown unaffected.
- `make ci` exit 0 from the worktree root — run twice, once by the implementer and once independently (grind: ruff/format/mypy-strict clean, 398 passed, coverage 95.80%).

Note: the branch commit intentionally carries no attribution trailers (authoring constraint); this squash-merge's message is composed here, and this PR body carries the attribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DaXES6cVMwC2dhc875o3e