### PR TITLE
fix(9k9.125.2): an empty claimed output is a transport failure, not reviewer garbage

### DIFF
--- a/src/user/.claude/skills/review-panel/dispatch_gate.py
+++ b/src/user/.claude/skills/review-panel/dispatch_gate.py
@@ -597,21 +597,23 @@ def ingest(args: argparse.Namespace) -> dict[str, Any]:
             f"no claim in this round assigned the output path {output}; a dispatch made without "
             "one leaves a hole in the ledger, and an unbounded lens is what the hole hides",
         )
-    if not output.is_file():
+    body = ""
+    if output.is_file():
+        try:
+            body = output.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            append_record(path, outcome_record(claimed, "unparseable", output))
+            raise Refusal(
+                "unparseable-output", f"cannot read the claimed output {output} as text: {exc}"
+            ) from exc
+    if not body.strip():
         append_record(path, outcome_record(claimed, "no-output", output))
         raise Refusal(
             "no-output",
-            f"the claimed output path {output} holds no file. Each attempt writes its own path, "
+            f"the claimed output path {output} holds nothing. Each attempt writes its own path, "
             "so nothing there means the route wrote nothing and the reviewer never ran: claim "
             f"again with reason {TRANSPORT_ERROR!r}, carrying the route's error as the evidence",
         )
-    try:
-        body = output.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError) as exc:
-        append_record(path, outcome_record(claimed, "unparseable", output))
-        raise Refusal(
-            "unparseable-output", f"cannot read the claimed output {output} as text: {exc}"
-        ) from exc
     try:
         report, recovery = parse_report(body)
     except Refusal:

--- a/src/user/.claude/skills/review-panel/dispatch_gate_test.py
+++ b/src/user/.claude/skills/review-panel/dispatch_gate_test.py
@@ -553,7 +553,6 @@ class TestIngest:
         "body",
         [
             "The change looks fine to me, no findings.",
-            "",
             '["correctness", "clean"]',
             "```\nnot json at all\n```",
         ],
@@ -592,6 +591,19 @@ class TestIngest:
         fails, and the attempt's own path is empty rather than holding a stale
         report from the attempt before it."""
         answer = authorize(round_dir, capsys)
+        refused = refuse(
+            ["ingest", "--out-dir", str(round_dir), "--output", answer["output_path"]], capsys
+        )
+        assert codes(refused) == ["no-output"]
+        assert "transport-error" in refused["errors"][0]["message"]
+        assert kinds(round_dir, "outcome")[0]["outcome"] == "no-output"
+
+    def test_a_claimed_path_holding_an_empty_file_is_a_transport_failure(self, round_dir, capsys):
+        """A route that dies mid-turn exits 0 having opened its file and written
+        nothing into it. Nothing came over the transport, so this is the route's
+        failure and not the reviewer's, however clean the exit status looked."""
+        answer = authorize(round_dir, capsys)
+        write_output(answer, "")
         refused = refuse(
             ["ingest", "--out-dir", str(round_dir), "--output", answer["output_path"]], capsys
         )

--- a/src/user/.claude/skills/review-panel/dispatch_gate_test.py
+++ b/src/user/.claude/skills/review-panel/dispatch_gate_test.py
@@ -598,12 +598,16 @@ class TestIngest:
         assert "transport-error" in refused["errors"][0]["message"]
         assert kinds(round_dir, "outcome")[0]["outcome"] == "no-output"
 
-    def test_a_claimed_path_holding_an_empty_file_is_a_transport_failure(self, round_dir, capsys):
+    @pytest.mark.parametrize("body", ["", " \n\t\n"])
+    def test_a_claimed_path_holding_an_empty_file_is_a_transport_failure(
+        self, round_dir, capsys, body
+    ):
         """A route that dies mid-turn exits 0 having opened its file and written
-        nothing into it. Nothing came over the transport, so this is the route's
+        nothing into it — sometimes literally nothing, sometimes a stray newline.
+        Nothing came over the transport either way, so this is the route's
         failure and not the reviewer's, however clean the exit status looked."""
         answer = authorize(round_dir, capsys)
-        write_output(answer, "")
+        write_output(answer, body)
         refused = refuse(
             ["ingest", "--out-dir", str(round_dir), "--output", answer["output_path"]], capsys
         )


### PR DESCRIPTION
The 9k9.125.2 investigation proved a real silent-loss mode in the codex plugin: a transport that dies mid-turn exits 0 with empty output (reproduced 20/20; the plugin's `rejectCompletion` is captured but never wired). This repo's one surface that consumes codex-transport output files — review-panel's dispatch gate — misattributed exactly that signature: `ingest` guarded only against a *missing* output file, so an existing-but-empty file fell through the parse ladder and was refused as `unparseable-output` ("the reviewer wrote garbage") instead of `no-output` ("the route died; the reviewer never ran"). harvest.md's contract prose already said the latter: "a dead route shows up as an exit 1 carrying a short provider error, and equally as an exit 0 carrying nothing."

The guard now reads the body before judging: unreadable → `unparseable-output` unchanged; missing file and empty/whitespace-only body → `no-output`, pointing the next claim at `transport-error`. The suite's `""` parameter moves out of the malformed-body list (where it pinned the wrong attribution) into its own transport-failure test.

- Red first: with the guard reverted, exactly the new test fails (`['unparseable-output'] == ['no-output']`); green after: 58 passed. Mutation-checked via backup-copy revert.
- ruff findings identical to pristine main (3 pre-existing, nothing new).
- Gates standalone from the worktree root: content-tests EXIT=0, content-lint EXIT=0.

Investigation record on `agents-config-9k9.125.2` (child of the broker-leak item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U59PwBh8cy2fTis8W3cBbo